### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/patternfly/patternfly-mcp/compare/1913d18b82ca50b57999cf1c6cf7c1100eff3e94...bb8f4be6da8629bef34beb2d82dc8ce826f68c44) (2025-11-30)
+
+
+### Tests
+*  stdio client refactor for e2e ([#16](https://github.com/patternfly/patternfly-mcp/pull/16)) ([ce9970c](https://github.com/patternfly/patternfly-mcp/commit/ce9970cec38a656d02d92ac94a8625dea80d2424))
+
+### Features
+*  memo cache expire, rollout callbacks ([#17](https://github.com/patternfly/patternfly-mcp/pull/17)) ([c9e4838](https://github.com/patternfly/patternfly-mcp/commit/c9e48389df6af11b60d90a1af7c3cc92248e3102))
+* **schemas** add component-schemas tool ([#12](https://github.com/patternfly/patternfly-mcp/pull/12)) ([4e58b28](https://github.com/patternfly/patternfly-mcp/commit/4e58b28452c6b608baccd98e2e466b7a1c33ea97))
+*  shortest distance search helpers ([#14](https://github.com/patternfly/patternfly-mcp/pull/14)) ([0f2b54a](https://github.com/patternfly/patternfly-mcp/commit/0f2b54ad941a003b1825030a1b541b5161f77936))
+*  expose server-instance stop, status ([#9](https://github.com/patternfly/patternfly-mcp/pull/9)) ([68222cb](https://github.com/patternfly/patternfly-mcp/commit/68222cb89efd3d9aa16057c0dfb39885680affd7))
+
+### Code Refactoring
+*  patternfly doc path updates ([#26](https://github.com/patternfly/patternfly-mcp/pull/26)) ([12334cf](https://github.com/patternfly/patternfly-mcp/commit/12334cf6932554ea7fdfb0d0871dbafdb6f97c0b))
+*  move from global to context options ([#10](https://github.com/patternfly/patternfly-mcp/pull/10)) ([aa134f6](https://github.com/patternfly/patternfly-mcp/commit/aa134f642b97529d2f29356dc09306f958303e93))
+
+### Bug Fixes
+*  os agnostic repoName ([#15](https://github.com/patternfly/patternfly-mcp/pull/15)) ([bb8f4be](https://github.com/patternfly/patternfly-mcp/commit/bb8f4be6da8629bef34beb2d82dc8ce826f68c44))
+
 ## 0.1.0 (2025-10-23)
 
 
@@ -18,4 +37,3 @@ All notable changes to this project will be documented in this file.
 *  mcp-config to patternfly package ([#4](https://github.com/patternfly/patternfly-mcp/pull/4)) ([c1e13eb](https://github.com/patternfly/patternfly-mcp/commit/c1e13ebadc2b0cacca2570bf95c406d8e5821916))
 *  move to nodejs 20 ([#3](https://github.com/patternfly/patternfly-mcp/pull/3)) ([c60fec1](https://github.com/patternfly/patternfly-mcp/commit/c60fec1a86ba6970575ded02bd82a8e7b1c8a2d6))
 *  move to patternfly branding ([#2](https://github.com/patternfly/patternfly-mcp/pull/2)) ([3000fb5](https://github.com/patternfly/patternfly-mcp/commit/3000fb5f7f20a8c4db727b6a4cdb269e3ca19241))
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patternfly/patternfly-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patternfly/patternfly-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/patternfly-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PatternFly documentation MCP server built with Node.js and TypeScript",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## What is it?
- chore(release): 0.2.0


## Notes
- Incremental updates to fix documentation links before we update console logging, http transport, tool plugins 
- see CHANGELOG for related updates, **2 important updates are included**
   - **schema props tooling** Returns prop and detail information regarding a component. Audit testing revealed the future of this tool may include being merged back into the search or returned component information so we relaxed exposing the README documentation.
   - **doc example and link updates** Recent updates to the pf-org site shifted how we were linking to things, moves over to using version information in the link paths. The future of this is a migration towards using generated documentation, most likely served via api

## Commits

### Tests
*  stdio client refactor for e2e ([#16](https://github.com/patternfly/patternfly-mcp/pull/16)) ([ce9970c](https://github.com/patternfly/patternfly-mcp/commit/ce9970cec38a656d02d92ac94a8625dea80d2424))

### Features
*  memo cache expire, rollout callbacks ([#17](https://github.com/patternfly/patternfly-mcp/pull/17)) ([c9e4838](https://github.com/patternfly/patternfly-mcp/commit/c9e48389df6af11b60d90a1af7c3cc92248e3102))
* **schemas** add component-schemas tool ([#12](https://github.com/patternfly/patternfly-mcp/pull/12)) ([4e58b28](https://github.com/patternfly/patternfly-mcp/commit/4e58b28452c6b608baccd98e2e466b7a1c33ea97))
*  shortest distance search helpers ([#14](https://github.com/patternfly/patternfly-mcp/pull/14)) ([0f2b54a](https://github.com/patternfly/patternfly-mcp/commit/0f2b54ad941a003b1825030a1b541b5161f77936))
*  expose server-instance stop, status ([#9](https://github.com/patternfly/patternfly-mcp/pull/9)) ([68222cb](https://github.com/patternfly/patternfly-mcp/commit/68222cb89efd3d9aa16057c0dfb39885680affd7))

### Code Refactoring
*  patternfly doc path updates ([#26](https://github.com/patternfly/patternfly-mcp/pull/26)) ([12334cf](https://github.com/patternfly/patternfly-mcp/commit/12334cf6932554ea7fdfb0d0871dbafdb6f97c0b))
*  move from global to context options ([#10](https://github.com/patternfly/patternfly-mcp/pull/10)) ([aa134f6](https://github.com/patternfly/patternfly-mcp/commit/aa134f642b97529d2f29356dc09306f958303e93))

### Bug Fixes
*  os agnostic repoName ([#15](https://github.com/patternfly/patternfly-mcp/pull/15)) ([bb8f4be](https://github.com/patternfly/patternfly-mcp/commit/bb8f4be6da8629bef34beb2d82dc8ce826f68c44))