### PR TITLE
refactor: cli as standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Model Context Protocol (MCP) is an open standard that enables AI assistants 
 ## Prerequisites
 
 - Node.js 20.0.0 or higher
-- npm (or another Node package manager)
+- NPM (or another Node package manager)
 
 ## Installation
 
@@ -63,7 +63,7 @@ These are the most relevant NPM scripts from package.json:
 - `build`: Build the TypeScript project (cleans dist, type-checks, bundles)
 - `build:clean`: Remove dist
 - `build:watch`: Build in watch mode
-- `start`: Run the built server (node dist/index.js)
+- `start`: Run the built server, CLI (node dist/cli.js)
 - `start:dev`: Run with tsx in watch mode (development)
 - `test`: Run linting, type-check, and unit tests in src/
 - `test:dev`: Jest watch mode for unit tests
@@ -182,7 +182,7 @@ Most MCP clients use a JSON configuration to specify how to start this server. T
   "mcpServers": {
     "patternfly-docs": {
       "command": "node",
-      "args": ["dist/index.js"],
+      "args": ["dist/cli.js"],
       "cwd": "/path/to/patternfly-mcp",
       "description": "PatternFly docs (local build)"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "zod": "3.25.76"
       },
       "bin": {
-        "patternfly-mcp": "dist/index.js",
-        "pf-mcp": "dist/index.js",
-        "pfmcp": "dist/index.js"
+        "patternfly-mcp": "dist/cli.js",
+        "pf-mcp": "dist/cli.js",
+        "pfmcp": "dist/cli.js"
       },
       "devDependencies": {
         "@cdcabrera/eslint-config-toolkit": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     ".": "./dist/index.js"
   },
   "bin": {
-    "patternfly-mcp": "dist/index.js",
-    "pf-mcp": "dist/index.js",
-    "pfmcp": "dist/index.js"
+    "patternfly-mcp": "dist/cli.js",
+    "pf-mcp": "dist/cli.js",
+    "pfmcp": "dist/cli.js"
   },
   "files": [
     "dist/**/*",
@@ -23,8 +23,8 @@
     "build:clean": "rm -rf dist",
     "build:watch": "npm run build -- --watch",
     "release": "changelog --non-cc --link-url https://github.com/patternfly/patternfly-mcp.git",
-    "start": "node dist/index.js --verbose --log-stderr",
-    "start:dev": "tsx watch src/index.ts",
+    "start": "node dist/cli.js --log-stderr",
+    "start:dev": "tsx watch src/cli.ts --verbose --log-stderr",
     "test": "npm run test:lint && npm run test:types && jest --roots=src/",
     "test:dev": "npm test -- --watchAll",
     "test:integration": "npm run build && jest --roots=tests/",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { main } from './index';
+
+main().catch(error => {
+  // Use console.error, log.error requires initialization
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { parseCliOptions, type CliOptions, type DefaultOptions } from './options';
 import { setOptions } from './options.context';
 import { runServer, type ServerInstance } from './server';
@@ -25,14 +23,5 @@ const main = async (programmaticOptions?: Partial<DefaultOptions>): Promise<Serv
     process.exit(1);
   }
 };
-
-// Start the server
-if (process.env.NODE_ENV !== 'local') {
-  main().catch(error => {
-    // Use console.error, log.error requires initialization
-    console.error('Failed to start server:', error);
-    process.exit(1);
-  });
-}
 
 export { main, main as start, type CliOptions, type ServerInstance };

--- a/tests/utils/stdioTransportClient.ts
+++ b/tests/utils/stdioTransportClient.ts
@@ -41,13 +41,13 @@ export interface StdioTransportClient {
  *
  * @param options - Server configuration options
  * @param options.command - Node command to run (default: 'node')
- * @param options.serverPath - Path to built server (default: process.env.SERVER_PATH || 'dist/index.js')
+ * @param options.serverPath - Path to built server (default: process.env.SERVER_PATH || 'dist/cli.js')
  * @param options.args - Additional args to pass to server, see app `CliOptions` for the full list (e.g., ['--docs-host'])
  * @param options.env - Environment variables for the child process
  */
 export const startServer = async ({
   command = 'node',
-  serverPath = process.env.SERVER_PATH || 'dist/index.js',
+  serverPath = 'dist/cli.js',
   args = [],
   env = {}
 }: StartOptions = {}): Promise<StdioTransportClient> => {


### PR DESCRIPTION
## What is it?
- refactor: cli as standalone

## Notes
- moves the cli into a standalone file, the combined file was creating issues and funky solutions
- this is technically a "breaking change" in that the MCP configuration should be updated on consuming clients, but this is alpha/beta 
- related #1 