### PR TITLE
fix: avoid recursive error handling

### DIFF
--- a/src/__tests__/__snapshots__/logger.test.ts.snap
+++ b/src/__tests__/__snapshots__/logger.test.ts.snap
@@ -37,6 +37,12 @@ exports[`formatLogEvent should return a formatted log event, all available field
 
 exports[`formatLogEvent should return a formatted log event, default 1`] = `"[DEBUG]: lorem ipsum, debug"`;
 
+exports[`formatLogEvent should return a formatted log event, null 1`] = `"[INFO]:"`;
+
+exports[`formatLogEvent should return a formatted log event, partial 1`] = `"[DEBUG]:"`;
+
+exports[`formatLogEvent should return a formatted log event, undefined 1`] = `"[INFO]:"`;
+
 exports[`formatUnknownError should attempt to return a formatted error on non-errors, bigint 1`] = `"9007199254740991n"`;
 
 exports[`formatUnknownError should attempt to return a formatted error on non-errors, boolean 1`] = `"Non-Error thrown: true"`;

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -134,6 +134,20 @@ describe('formatLogEvent', () => {
         args: [1, 2, 3],
         transport: 'dolorSit'
       }
+    },
+    {
+      description: 'undefined',
+      event: undefined
+    },
+    {
+      description: 'null',
+      event: null
+    },
+    {
+      description: 'partial',
+      event: {
+        level: 'debug'
+      }
     }
   ])('should return a formatted log event, $description', ({ event }) => {
     expect(formatLogEvent(event as any)).toMatchSnapshot();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -120,8 +120,10 @@ const formatUnknownError = (value: unknown): string => {
  * @param event - Log event to format
  */
 const formatLogEvent = (event: LogEvent) => {
-  const eventLevel = `[${event.level.toUpperCase()}]`;
-  const message = event.msg || '';
+  const level = event?.level?.toUpperCase() || 'INFO';
+  const eventLevel = `[${level}]`;
+  const message = event?.msg || '';
+
   const rest = event?.args?.map(arg => {
     try {
       return typeof arg === 'string' ? arg : JSON.stringify(arg);
@@ -129,6 +131,7 @@ const formatLogEvent = (event: LogEvent) => {
       return String(arg);
     }
   }).join(' ') || '';
+
   const separator = rest ? '\t:' : '';
 
   return `${eventLevel}: ${message}${separator}${rest}`.trim();


### PR DESCRIPTION
## What is it?
- fix: avoid recursive error handling
   * logger, avoid using log to broadcast its own errors
   * logger, move log format into a default helper

## Notes
- closes #60 