### PR TITLE
feat(patternFly): find closest pf version

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -11,6 +11,7 @@
     "onsessionclosed",
     "patternfly",
     "rereview",
+    "rsort",
     "sparkline",
     "streamable",
     "unrepresentable",

--- a/guidelines/agent_behaviors.md
+++ b/guidelines/agent_behaviors.md
@@ -118,11 +118,15 @@ When implementing tools that interact with the local filesystem, always use `res
 ```typescript
 import { resolveLocalPathFunction } from './server.getResources';
 // ...
-const safePath = await resolveLocalPathFunction(requestedPath, rootDir);
+let safePath;
 
-if (!safePath) {
+try {
+  safePath = resolveLocalPathFunction(requestedPath);
+} catch {
   throw new McpError(ErrorCode.InvalidParams, 'Access denied');
 }
+
+// use safePath for subsequent file operations
 ```
 
 ### 6.2 Plugin Isolation

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@patternfly/patternfly-component-schemas": "1.2.0",
         "fastest-levenshtein": "1.0.16",
         "pid-port": "2.0.1",
+        "semver": "7.7.3",
         "zod": "4.3.6"
       },
       "bin": {
@@ -24,6 +25,7 @@
         "@cdcabrera/eslint-config-toolkit": "^0.4.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.0.10",
+        "@types/semver": "7.7.1",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
         "@typescript-eslint/parser": "^8.54.0",
         "changelog-light": "^3.0.5",
@@ -98,6 +100,16 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/eslint-parser": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
@@ -115,6 +127,16 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0",
         "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -162,6 +184,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -3575,6 +3607,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4961,19 +5000,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/changelog-light/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -5541,19 +5567,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cspell/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -6162,19 +6175,6 @@
         "eslint": ">=6.0.0"
       }
     },
-    "node_modules/eslint-compat-utils/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -6328,6 +6328,16 @@
         "node": "*"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-jest": {
       "version": "29.12.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.12.1.tgz",
@@ -6391,19 +6401,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-json": {
@@ -6524,19 +6521,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -6625,6 +6609,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "62.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz",
@@ -6659,19 +6653,6 @@
       },
       "peerDependencies": {
         "eslint": ">=9.38.0"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
@@ -8512,19 +8493,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -9081,19 +9049,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
@@ -9474,19 +9429,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -10892,13 +10834,15 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -11814,19 +11758,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ts-jest": ">=20.0.0"
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -59,12 +59,14 @@
     "@patternfly/patternfly-component-schemas": "1.2.0",
     "fastest-levenshtein": "1.0.16",
     "pid-port": "2.0.1",
+    "semver": "7.7.3",
     "zod": "4.3.6"
   },
   "devDependencies": {
     "@cdcabrera/eslint-config-toolkit": "^0.4.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.10",
+    "@types/semver": "7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",
     "changelog-light": "^3.0.5",

--- a/src/__tests__/__snapshots__/options.defaults.test.ts.snap
+++ b/src/__tests__/__snapshots__/options.defaults.test.ts.snap
@@ -32,10 +32,10 @@ exports[`options defaults should return specific properties: defaults 1`] = `
   "nodeVersion": 22,
   "patternflyOptions": {
     "availableResourceVersions": [
-      "v6",
+      "6.0.0",
     ],
     "default": {
-      "defaultVersion": "v6",
+      "defaultVersion": "6.0.0",
       "versionStrategy": "highest",
       "versionWhitelist": [
         "@patternfly/react-core",

--- a/src/__tests__/__snapshots__/server.toolsUser.test.ts.snap
+++ b/src/__tests__/__snapshots__/server.toolsUser.test.ts.snap
@@ -75,7 +75,7 @@ exports[`normalizeFilePackage handles file URL 1`] = `
 exports[`normalizeFilePackage handles http URL (not file) 1`] = `
 {
   "fsReadDir": "/",
-  "isFilePath": true,
+  "isFilePath": false,
   "isFileUrl": false,
   "isUrlLike": true,
   "normalizedUrl": "/module.mjs",
@@ -89,7 +89,7 @@ exports[`normalizeFilePackage handles invalid file URLs, encoding 1`] = `
 {
   "error": "true",
   "fsReadDir": "/",
-  "isFilePath": false,
+  "isFilePath": true,
   "isFileUrl": true,
   "isUrlLike": true,
   "normalizedUrl": "/%E0%A4%A",
@@ -184,7 +184,7 @@ exports[`normalizeFileUrl handles invalid file URLs, encoding 1`] = `
 {
   "error": "true",
   "fsReadDir": "/",
-  "isFilePath": false,
+  "isFilePath": true,
   "isFileUrl": true,
   "isUrlLike": true,
   "normalizedUrl": "/%E0%A4%A",

--- a/src/__tests__/patternFly.helpers.test.ts
+++ b/src/__tests__/patternFly.helpers.test.ts
@@ -1,0 +1,156 @@
+import { findClosestPatternFlyVersion } from '../patternFly.helpers';
+import { readLocalFileFunction } from '../server.getResources';
+import { DEFAULT_OPTIONS } from '../options.defaults';
+
+jest.mock('../server.getResources', () => ({
+  ...jest.requireActual('../server.getResources'),
+  readLocalFileFunction: {
+    memo: jest.fn()
+  }
+}));
+
+const mockReadLocalFile = readLocalFileFunction.memo as jest.Mock;
+
+describe('findClosestPatternFlyVersion', () => {
+  it.each([
+    {
+      description: 'non-existent path',
+      path: '/mock/package.json',
+      expected: '6.0.0'
+    },
+    {
+      description: 'non-string path',
+      path: 1,
+      expected: '6.0.0'
+    }
+  ])('should return default version if no package.json is found, $description', async ({ path, expected }) => {
+    const version = await findClosestPatternFlyVersion(path as any);
+
+    expect(version).toBe(expected);
+  });
+
+  it.each([
+    {
+      description: 'basic',
+      deps: {
+        '@patternfly/react-core': '^5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'greater than or equal, major, minor, patch',
+      deps: {
+        '@patternfly/react-core': '<=4.5.5'
+      },
+      expected: '4.0.0'
+    },
+    {
+      description: 'range, greater than less than equal',
+      deps: {
+        '@patternfly/react-core': '>=4.0.0 <=5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'range, inclusive',
+      deps: {
+        '@patternfly/react-core': '4.0.0 - 5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'git path',
+      deps: {
+        '@patternfly/react-core': 'https://github.com/patternfly/patternfly-mcp.git#v5'
+      },
+      expected: '6.0.0'
+    },
+    {
+      description: 'unknown local path',
+      deps: {
+        '@patternfly/react-core': './patternfly-mcp#v5'
+      },
+      expected: '6.0.0'
+    },
+    {
+      description: 'mismatched versions',
+      deps: {
+        '@patternfly/patternfly': '^4.0.0',
+        '@patternfly/react-core': '^6.0.0'
+      },
+      expected: '6.0.0'
+    },
+    {
+      description: 'fuzzy match -next',
+      deps: {
+        '@patternfly/react-core-next': '^5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'fuzzy match -rc',
+      deps: {
+        '@patternfly/react-core-rc': '^5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'fuzzy match -alpha',
+      deps: {
+        '@patternfly/patternfly-alpha': '^5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'fuzzy match -beta',
+      deps: {
+        '@patternfly/patternfly-beta': '^5.0.0'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'attempted fuzzy match scope',
+      deps: {
+        '@scope/patternfly-alt': '^5.0.0'
+      },
+      expected: '6.0.0'
+    },
+    {
+      description: 'attempted false positive fuzzy match',
+      deps: {
+        'patternfly/patternfly': '^5.0.0'
+      },
+      expected: '6.0.0'
+    },
+    {
+      description: 'wildcard match',
+      deps: {
+        '@patternfly/patternfly': '^5.x.x'
+      },
+      expected: '5.0.0'
+    },
+    {
+      description: 'mismatched versions with expanded available versions',
+      deps: {
+        '@patternfly/patternfly': '^4.0.0',
+        '@patternfly/react-core': '^5.0.0'
+      },
+      expected: '5.0.0'
+    }
+  ])('should attempt to match whitelisted packages, $description', async ({ deps, expected }) => {
+    mockReadLocalFile.mockResolvedValue(JSON.stringify({
+      dependencies: { ...deps }
+    }));
+
+    // Use the PF MCP package.json so we can override with "mockReadLocalFile". Override available resource versions.
+    const version = await findClosestPatternFlyVersion(process.cwd(), {
+      ...DEFAULT_OPTIONS,
+      patternflyOptions: {
+        ...DEFAULT_OPTIONS.patternflyOptions,
+        availableResourceVersions: ['4.0.0', '5.0.0', '6.0.0']
+      }
+    });
+
+    expect(version).toBe(expected);
+  });
+});

--- a/src/__tests__/server.toolsUser.test.ts
+++ b/src/__tests__/server.toolsUser.test.ts
@@ -3,8 +3,6 @@ import { basename, resolve } from 'node:path';
 import { z } from 'zod';
 import {
   createMcpTool,
-  isFilePath,
-  isUrlLike,
   normalizeFilePackage,
   normalizeFilePath,
   normalizeFileUrl,
@@ -95,46 +93,6 @@ describe('sanitizeStaticToolName', () => {
     });
 
     expect(sanitizeStaticToolName(proxy)).toBeUndefined();
-  });
-});
-
-describe('isFilePath', () => {
-  it.each([
-    { description: 'absolute path', file: '/path/to/file.txt' },
-    { description: 'absolute path ref no extension', file: '/path/to/another/file' },
-    { description: 'min file extension', file: 'path/to/another/file.y' },
-    { description: 'potential multiple extensions', file: 'path/to/another/file.test.js' },
-    { description: 'current dir ref', file: './path/to/another/file.txt' },
-    { description: 'parent dir ref', file: '../path/to/another/file.txt' }
-  ])('should validate $description', ({ file }) => {
-    expect(isFilePath(file)).toBe(true);
-  });
-
-  it.each([
-    { description: 'no file extension or dir ref', file: 'path/to/another/file' }
-  ])('should fail, $description', ({ file }) => {
-    expect(isFilePath(file)).toBe(false);
-  });
-});
-
-describe('isUrlLike', () => {
-  it.each([
-    { description: 'http', url: 'http://example.com' },
-    { description: 'https', url: 'https://example.com' },
-    { description: 'file', url: 'file:///path/to/file.txt' },
-    { description: 'node', url: 'node://path/to/file.txt' },
-    { description: 'data', url: 'data:text/plain;base64,1234567890==' }
-  ])('should validate $description', ({ url }) => {
-    expect(isUrlLike(url)).toBe(true);
-  });
-
-  it.each([
-    { description: 'invalid protocol', url: 'ftp://example.com' },
-    { description: 'random', url: 'random://example.com' },
-    { description: 'null', url: null },
-    { description: 'undefined', url: undefined }
-  ])('should fail, $description', ({ url }) => {
-    expect(isUrlLike(url as any)).toBe(false);
   });
 });
 

--- a/src/options.defaults.ts
+++ b/src/options.defaults.ts
@@ -348,9 +348,9 @@ const LOG_BASENAME = 'pf-mcp:log';
  * Default PatternFly-specific options.
  */
 const PATTERNFLY_OPTIONS: PatternFlyOptions = {
-  availableResourceVersions: ['v6'],
+  availableResourceVersions: ['6.0.0'],
   default: {
-    defaultVersion: 'v6',
+    defaultVersion: '6.0.0',
     versionWhitelist: [
       '@patternfly/react-core',
       '@patternfly/patternfly'

--- a/src/patternFly.helpers.ts
+++ b/src/patternFly.helpers.ts
@@ -1,0 +1,91 @@
+import semver, { type SemVer } from 'semver';
+import { getOptions } from './options.context';
+import {
+  findNearestPackageJson,
+  matchPackageVersion,
+  readLocalFileFunction
+} from './server.getResources';
+import { fuzzySearch } from './server.search';
+import { memo } from './server.caching';
+
+/**
+ * Find the closest PatternFly version used within the project context.
+ *
+ * @note In the future the available versions of PatternFly will be determined by the available resources.
+ * In the short-term we limit the available versions via `patternflyOptions.availableResourceVersions`.
+ *
+ * @note In the future consider adding a log.debug to the try/catch block if/when the find closest version
+ * is integrated into tooling and resources.
+ *
+ * Logic:
+ * 1. Locates the nearest package.json.
+ * 2. Scans whitelisted dependencies using fuzzy matching.
+ * 3. Aggregates, filters all detected versions that exist in the documentation catalog.
+ * 4. Resolves the final version using the optional configured strategy (e.g. target the highest version, target the lowest version).
+ *
+ * @param contextPathOverride - Optional override for the context path to search for package.json
+ * @param options - Global options
+ * @returns Matched PatternFly semver version (e.g., '6.0.0', '5.0.0', '4.0.0')
+ */
+const findClosestPatternFlyVersion = async (
+  contextPathOverride: string | undefined = undefined,
+  options = getOptions()
+): Promise<string> => {
+  const availableVersions = options.patternflyOptions.availableResourceVersions;
+  const { defaultVersion, versionWhitelist, versionStrategy } = options.patternflyOptions.default;
+  const pkgPath = findNearestPackageJson(contextPathOverride || options.contextPath);
+  const updatedDefaultVersion = semver.coerce(defaultVersion)?.version || defaultVersion;
+
+  if (!pkgPath) {
+    return updatedDefaultVersion;
+  }
+
+  try {
+    const content = await readLocalFileFunction.memo(pkgPath);
+    const pkg = JSON.parse(content);
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies } as Record<string, string>;
+    const depNames = Object.keys(allDeps);
+
+    const detectedVersions = new Set<SemVer>();
+
+    for (const pkgName of versionWhitelist) {
+      // Allow for variations like -next or -alpha with fuzzySearch maxDistance
+      const matches = fuzzySearch(pkgName, depNames, {
+        maxDistance: 1,
+        isFuzzyMatch: true
+      });
+
+      for (const match of matches) {
+        const versionMatch = matchPackageVersion(allDeps[match.item], availableVersions);
+
+        if (versionMatch) {
+          detectedVersions.add(versionMatch);
+        }
+      }
+    }
+
+    if (detectedVersions.size === 0) {
+      return updatedDefaultVersion;
+    }
+
+    if (detectedVersions.size === 1) {
+      return Array.from(detectedVersions)[0]?.version as string;
+    }
+
+    const versionsArray = Array.from(detectedVersions);
+    const maxVersion = versionStrategy === 'highest'
+      ? semver.maxSatisfying(versionsArray, '*')
+      : semver.minSatisfying(versionsArray, '*');
+
+    return maxVersion?.version || updatedDefaultVersion;
+  } catch {
+    return updatedDefaultVersion;
+  }
+};
+
+/**
+ * Memoized version of findClosestPatternFlyVersion.
+ */
+findClosestPatternFlyVersion.memo = memo(findClosestPatternFlyVersion);
+
+export { findClosestPatternFlyVersion };


### PR DESCRIPTION
## What is it?
- feat(patternFly): find closest pf version
   * build, semver package for version checks
   * docs, guidance example aligned
   * options, semver defaults for available patternfly
   * patternFly.helpers, find closest pf version
   * server.getResources, findNearestPackageJson, matchPackageVersion
   * server.helpers, expand isUrl, add isPath
   * server.toolsUser, move to isUrl, isPath from server.helpers

## Notes
- Adds base functions as prep for finding the closest PatternFly version to provide additional prompt/tooling/resource context. This will be activated in subsequent work.
- Related to the work by @evwilkin here, https://github.com/evwilkin/patternfly-mcp/tree/feature/version-selection
- updates #21 #49 