### PR TITLE
fix(resources): incorrect schemas mimeType

### DIFF
--- a/src/resource.patternFlySchemasIndex.ts
+++ b/src/resource.patternFlySchemasIndex.ts
@@ -52,7 +52,7 @@ const listResources = async () => {
     .forEach(([version]) => {
       resources.push({
         uri: `patternfly://schemas/index?version=${encodeURIComponent(version)}`,
-        mimeType: 'application/json',
+        mimeType: 'text/markdown',
         name: `JSON Component Schemas Index (${version})`,
         description: `JSON component schemas for PatternFly version ${version}. ${URI_DESCRIPTION}`
       });


### PR DESCRIPTION
<!--
PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues for confirmation that the work isn't already in progress.
- Review our [PR contributing guidelines](https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md#pull-requests).
-->
## What is it?
<!-- Summary of changes/additions/commits -->
- fix(resources): incorrect schemas mimeType

### Notes
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->
- minor mimeType issue. the content comes out as `JSON` but reads as `markdown`.
- affects the versioned resource of schemas, the default is unaffected. 
   - "better" mcp clients are able to bypass the issue. 
   - "lesser" mcp clients may require being redirected by a user

<!-- ## How to test-->
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
<!--
### Unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### E2E test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #21 