### PR TITLE
docs: add contributor repo skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../guidelines/skills

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../guidelines/skills

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,13 @@ your contribution is aligned with the project's goals.
    ```
   All tests should pass, and the application should start successfully with confirmation messaging in the terminal.
 
+##### Windows and repository symlinks
+
+The repo uses **symlinks** so agent tools can find shared skills (for example `.agents/skills` and `.claude/skills` point at `guidelines/skills`). On **Windows**, a plain clone can leave those as plain files instead of links, which breaks that layout.
+
+- Prefer **Developer Mode** (Settings → Privacy & security → For developers) so Git can create symlinks without running as Administrator, **or** clone with symlink support enabled (for example `git clone -c core.symlinks=true …`).
+- If symlinks were not created, enable `core.symlinks` and re-check out the affected paths, or work from **WSL** / **Git for Windows** with symlink support configured.
+
 #### Development workflow
 - Make changes to the codebase
 - Run tests to verify your changes do not break existing functionality

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -2,6 +2,7 @@
   "language": "en",
   "words": [
     "amet",
+    "codemods",
     "ized",
     "llms",
     "midrun",

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -16,6 +16,12 @@ Agent-specific guidelines for the PatternFly MCP project, optimized for machine 
 - [Agent Coding](./agent_coding.md) - Coding standards
 - [Agent Testing](./agent_testing.md) - Testing procedures
 
+### Skills
+
+- [Add docs links](./skills/add-docs-links/SKILL.md) - Add documentation links to `src/docs.json` in a structured way (format, duplicate check, URL confirmation, tests)
+
+**Note:** `guidelines/skills/` is the canonical location for skills. Repo symlinks point here so agents can discover them: `.agents/skills` (Cursor), `.claude/skills` (Claude). The `.agent/` directory (no “s”) is reserved for each developer’s local work and is off limits—do not use it for shared skills or guidelines.
+
 ## User Guide
 
 ### Available Trigger Phrases
@@ -29,11 +35,12 @@ Agents should use these phrases as signals to consult specific documentation and
 | **"review tool usage"**             | Review `docs/usage.md` for built-in tools and configuration.                                                                                           |
 | **"review development guide"**      | Review `docs/development.md` for CLI, API, and plugin authoring.                                                                                       |
 | **"create an example tool plugin"** | Review `guidelines/agent_coding.md`, `docs/development.md`, `docs/examples/*`, and `src/*` for context, coding standards, and existing example formats. |
+| **"add documentation links"** / **"add doc entries"** / **"register docs"** / **"update docs.json"** / **"contribute to docs.json"** | Follow `guidelines/skills/add-docs-links/SKILL.md`: docs.json format, duplicate check, raw URL confirmation, then run unit tests and update meta. |
 
 ## Guidelines Processing Order
 
 1. **Guidelines Directory** (all files in the `guidelines/` directory)
-2. **Local Guidelines** (`.agent/` directory)
+2. **Local guidelines** (`.agent/` directory) — reserved for each user’s agent interaction; gitignored and off limits for shared repo assets. Do not create or reference shared skills or guidelines in `.agent/`.
 
 ## Maintaining This Directory
 

--- a/guidelines/skills/add-docs-links/SKILL.md
+++ b/guidelines/skills/add-docs-links/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: add-docs-links
+description: Maintains the PatternFly MCP documentation catalog in src/docs.json—add, edit, or remove entries with correct raw URLs, meta, and validation. Use when the user asks to add or register documentation links, update or fix docs.json entries, remove catalog rows, contribute to the docs catalog, or align with docs.json tests and CI audit.
+---
+
+# Add Documentation Links to docs.json
+
+## When to use
+
+User wants to **add**, **change**, or **remove** entries in `src/docs.json`, or fix broken / unreachable catalog links. They may paste **any GitHub URL** (blob or raw); you convert blob → raw, pick refs, verify reachability, shape entries, update `meta` and `generated`, and run tests.
+
+For **editing or removing**: locate the entry by `path` or component key; after changes, recompute `meta.totalEntries`, `meta.totalDocs`, set `generated` to current ISO time, run `npm test`. Same constraints as adds (whitelist, unique `path`, base-hash count).
+
+## Workflow
+
+1. **Resolve the raw URL and ref (git hash/branch)**
+   - Decide repo and file path (e.g. `patternfly/patternfly-org`, `patternfly/patternfly-react`).
+   - **Why SHAs:** Pinned commit SHAs keep each `path` immutable until deliberately updated. See [reference.md](reference.md#path-raw-url).
+   - Prefer an **existing ref** already in `docs.json` for that repo (keeps `baseHashes.size === 5` in unit tests). Extract from an existing entry’s `path`.
+   - If a new ref is required: resolve SHA (e.g. GitHub API `GET /repos/{owner}/{repo}/commits?sha={branch}`) or use a stable tag in the raw URL.
+
+2. **Build the raw URL (must be whitelisted)**
+   - `path` must match the whitelist in `src/options.defaults.ts` (`patternflyOptions.urlWhitelist`). See [reference.md](reference.md#url-whitelist-allowed-domains).
+   - **Maintainer-controlled:** Avoid changing the whitelist; new domains delay review.
+   - Allowed bases: `https://patternfly.org`, `https://github.com/patternfly`, `https://raw.githubusercontent.com/patternfly`. Use **https** for every new URL.
+   - GitHub raw pattern: `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path-to-file}`.
+
+3. **Confirm the URL is reachable**
+   - Raw URL must return HTTP 200–299 (e.g. `curl -sI -o /dev/null -w "%{http_code}" "<url>"` or `tests/audit/utils/checkUrl.ts`). If unreachable, fix ref/path or do not add.
+
+4. **Avoid duplicate paths**
+   - Each `path` is unique across the file; `src/__tests__/docs.json.test.ts` fails on duplicates with a clear report. Scan before adding to avoid churn.
+
+5. **Add or update entries**
+   - Full field list and types: [reference.md — Entry format](reference.md#entry-format). Insert under the right PascalCase component key; preserve project ordering (e.g. alphabetical keys) when editing.
+
+6. **Update `meta` and `generated`**
+   - `meta.totalEntries` = number of keys in `docs`.
+   - `meta.totalDocs` = total entries across all arrays.
+   - `generated` = current ISO timestamp (`new Date().toISOString()`).
+
+7. **Run unit tests and snapshots**
+   - From repo root: `npm test` (or `jest --selectProjects unit --roots=src/`).
+   - `docs.json.test.ts` validates duplicates, `meta`, and base-hash count. Coordinate before changing the expected base-hash count.
+   - If snapshots fail after catalog changes, update them intentionally—common: `src/__tests__/docs.embedded.test.ts` (`EMBEDDED_DOCS`), and tool/resource tests under `src/__tests__/` that snapshot docs-derived output (e.g. `tool.patternFlyDocs.test.ts`, `tool.searchPatternFlyDocs.test.ts`, `resource.patternFlyDocs*.test.ts`). Use the project’s usual Jest update flow (e.g. `npm test -- -u` scoped to the failing file).
+
+**CI:** `.github/workflows/audit.yml` runs on PRs touching `src/docs.json` or `tests/audit/**` and samples links for reachability (`tests/audit/`).
+
+## Quick checks
+
+- [ ] Blob URLs converted to raw; ref reused from `docs.json` when possible.
+- [ ] `path` is whitelisted and uses `https`.
+- [ ] Raw URL returns 2xx.
+- [ ] No duplicate `path` values.
+- [ ] Entry shape matches [reference.md](reference.md#entry-format); correct PascalCase key.
+- [ ] `meta.totalEntries`, `meta.totalDocs`, and `generated` updated.
+- [ ] `npm test` passes; snapshots updated only where catalog-driven output changed.

--- a/guidelines/skills/add-docs-links/reference.md
+++ b/guidelines/skills/add-docs-links/reference.md
@@ -1,0 +1,110 @@
+# docs.json Reference
+
+## File location
+
+- Catalog: `src/docs.json`
+- Unit test: `src/__tests__/docs.json.test.ts`
+- Link audit: `tests/audit/docs.audit.test.ts` (samples links and checks reachability)
+- **CI:** `.github/workflows/audit.yml` runs a daily audit (and on PRs that change `src/docs.json` or `tests/audit/**`), executing the audit tests so links in `docs.json` are periodically checked for reachability.
+
+## Top-level structure
+
+Illustrative shape only—**do not copy** `generated`, `meta.totalEntries`, or `meta.totalDocs` from this block; those must always match the real `src/docs.json` after your edit (and `meta` is validated by unit tests).
+
+```json
+{
+  "version": "1",
+  "generated": "<ISO-8601 UTC from Date.prototype.toISOString()>",
+  "meta": {
+    "totalEntries": "<number of keys in docs>",
+    "totalDocs": "<total entry count across all arrays>",
+    "source": "patternfly-mcp-internal"
+  },
+  "docs": {
+    "ComponentName": [ /* array of entries */ ]
+  }
+}
+```
+
+- `meta.totalEntries`: number of keys in `docs` (component count).
+- `meta.totalDocs`: total number of doc entries across all keys.
+- `docs`: keys are PascalCase component names; values are arrays of entry objects.
+
+## Entry format
+
+Each entry in `docs.<ComponentName>[]`:
+
+| Field         | Type   | Example |
+|---------------|--------|---------|
+| `displayName` | string | `"About Modal"` |
+| `description` | string | `"Design Guidelines for the about modal component."` |
+| `pathSlug`    | string | `"about-modal"` |
+| `section`     | string | `"components"` |
+| `category`    | string | Match sibling entries in `docs.json` for the same kind of doc (e.g. `design-guidelines`, `react`, `accessibility`); the catalog uses additional values—copy an existing entry’s `category` when unsure. |
+| `source`      | string | `"github"` |
+| `path`        | string | Full raw GitHub URL (see below) |
+| `version`     | string | `"v6"` \| `"v5"` |
+
+### path (raw URL)
+
+- Pattern: `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path-to-file}`
+- `ref`: branch name, tag (e.g. `v5`), or **commit SHA** (preferred for v6 org/react-style links).
+
+**Why commit SHAs are used (instead of only `main` / a moving branch):** A pinned SHA makes the fetched doc **immutable** for that URL: the catalog always resolves to the same file content until someone intentionally updates the ref. Branch heads change as upstream merges; without a pin, links could silently point at different text, break if files move, or make audits and support harder to reason about. Tags (e.g. `v5`) can also pin a release line; the project still limits how many distinct refs it tracks (see unit test `baseHashes`).
+
+- Example: `https://raw.githubusercontent.com/patternfly/patternfly-org/2d5fec39ddb8aa32ce78c9a63cdfc1653692b193/packages/documentation-site/patternfly-docs/content/components/about-modal/about-modal.md`
+- **Must be whitelisted:** see [URL whitelist](#url-whitelist-allowed-domains) below.
+
+## URL whitelist (allowed domains)
+
+External paths and references are limited by a PatternFly URL whitelist so the server only fetches from allowed origins.
+
+- **Defined in:** `src/options.defaults.ts` → `PATTERNFLY_OPTIONS` → `patternflyOptions.urlWhitelist`
+- **Used by:** `tool.patternFlyDocs` (validates `urlList` via `assertInputUrlWhiteListed`); matching logic in `server.helpers.ts` → `isWhitelistedUrl`.
+- **Default entries (prefix match):**
+  - `https://patternfly.org` — patternfly.org and subdomains (e.g. `www.patternfly.org`, `v6.docs.patternfly.org`)
+  - `https://github.com/patternfly` — any path under `github.com/patternfly`
+  - `https://raw.githubusercontent.com/patternfly` — any path under `raw.githubusercontent.com/patternfly` (e.g. `patternfly-org`, `patternfly-react`)
+- **Protocols:** `urlWhitelistProtocols` may include both `http` and `https` in server configuration. **For `docs.json`:** always use `https://` URLs only; do not add new `http://` catalog paths.
+
+Any new `path` in `docs.json` must match one of these prefixes (protocol + host + path prefix). URLs that do not match will be rejected when the tool is used with a `urlList` or when the server fetches by path.
+
+**Maintainer-controlled:** The whitelist is controlled at the maintainer level. It is recommended to avoid updating it; if it is modified, your contribution will be delayed while the new whitelisted domain is reviewed.
+
+## Duplicate check
+
+- Every `path` in the file must be **unique** across all entries.
+- **Automatically enforced by unit test:** `src/__tests__/docs.json.test.ts` builds a map of each `path` to the list of entries that use it; if any path has more than one entry, the test fails and reports each duplicate path and which component/category entries reference it. Run `npm test` to confirm no duplicates. Optionally, before adding an entry, collect all `path` values (e.g. `Object.values(docs.docs).flat().map(e => e.path)`) to avoid a failing test.
+
+## GitHub ref (hash) lookup
+
+- **Use existing refs**: Prefer the ref already used in `docs.json` for that repo (same owner/repo). Extract the ref from an existing `path`: the segment after `raw.githubusercontent.com/owner/repo/` and before the next `/`.
+- **New ref via API**: For branch `main` of `patternfly/patternfly-org`:
+  - `GET https://api.github.com/repos/patternfly/patternfly-org/commits/main` (or `commits?sha=main`) and use the response `sha` in the raw URL.
+- **Confirm raw URL**: After building the URL, fetch it (e.g. `curl -sI` or the project’s `checkUrl`) and ensure HTTP 200–299.
+
+## Unit test constraints
+
+From `src/__tests__/docs.json.test.ts`:
+
+1. No duplicate `path` values.
+2. `meta.totalEntries` === number of keys in `docs`.
+3. `meta.totalDocs` === total number of entries in all arrays.
+4. Number of unique “base hashes” (refs per repo) is **5** (v6 org, v6 react, v5 org, codemods, ai-helpers). When adding links, use existing refs so this count does not change unless the project explicitly adds a new source.
+
+## Example new entry
+
+```json
+{
+  "displayName": "New Component",
+  "description": "Design Guidelines for the new component.",
+  "pathSlug": "new-component",
+  "section": "components",
+  "category": "design-guidelines",
+  "source": "github",
+  "path": "https://raw.githubusercontent.com/patternfly/patternfly-org/2d5fec39ddb8aa32ce78c9a63cdfc1653692b193/packages/documentation-site/patternfly-docs/content/components/new-component/new-component.md",
+  "version": "v6"
+}
+```
+
+Place under `docs["NewComponent"]` (or the correct PascalCase key); create the key if it does not exist.

--- a/src/__tests__/__snapshots__/tool.searchPatternFlyDocs.test.ts.snap
+++ b/src/__tests__/__snapshots__/tool.searchPatternFlyDocs.test.ts.snap
@@ -50,23 +50,3 @@ exports[`searchPatternFlyDocsTool, callback should have a specific markdown form
   },
 ]
 `;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, default: search 1`] = `"# Search results for PatternFly version "v6" and "Button". Showing 2 exact matches."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with "*" searchQuery all: search 1`] = `"# Search results for PatternFly version "v6" and "all" resources. Only showing the first 10 results. There are 806 potential match variations. Try searching with a more specific query."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with "all" searchQuery all: search 1`] = `"# Search results for PatternFly version "v6" and "all" resources. Only showing the first 10 results. There are 806 potential match variations. Try searching with a more specific query."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with explicit valid version: search 1`] = `"# Search results for PatternFly version "v6" and "Button". Showing 2 exact matches."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with lower case componentName: search 1`] = `"# Search results for PatternFly version "v6" and "button". Showing 2 exact matches."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with made up componentName: search 1`] = `"No PatternFly resources found matching "lorem ipsum dolor sit amet""`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with multiple words: search 1`] = `"# Search results for PatternFly version "v6" and "Button Card Table". Showing 4 related matches."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with partial componentName: search 1`] = `"# Search results for PatternFly version "v6" and "ton". Showing 5 related matches."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with trimmed componentName: search 1`] = `"# Search results for PatternFly version "v6" and " Button  ". Showing 2 exact matches."`;
-
-exports[`searchPatternFlyDocsTool, callback should parse parameters, with upper case componentName: search 1`] = `"# Search results for PatternFly version "v6" and "BUTTON". Showing 2 exact matches."`;

--- a/src/__tests__/docs.json.test.ts
+++ b/src/__tests__/docs.json.test.ts
@@ -1,6 +1,20 @@
 import docs from '../docs.json';
 
 describe('docs.json', () => {
+  it('should have a valid top-level generated timestamp (ISO date string)', () => {
+    expect(docs.generated).toBeDefined();
+    expect(typeof docs.generated).toBe('string');
+    expect(docs.generated.length).toBeGreaterThan(0);
+
+    const rawDate = docs.generated;
+    const parsedDate = Date.parse(rawDate);
+
+    expect(Number.isNaN(parsedDate)).toBe(false);
+
+    // Canonical ISO 8601 UTC form from Date.prototype.toISOString()
+    expect(new Date(parsedDate).toISOString()).toBe(rawDate);
+  });
+
   it('should have metadata reflective of its content and unique links per each entry', () => {
     const linkMap = new Map<string, string[]>();
     const allLinks = new Set<string>();
@@ -49,6 +63,9 @@ describe('docs.json', () => {
     /**
      * Confirm we have limited hashes, avoid variation within pf versions
      * If this increases, hashes need to be realigned. Do not randomly change this value.
+     * If you are updating `docs.json` with an agent confirm altering this value is acceptable
+     * when you open your MR/PR. You may be asked to change your git hash to one of the
+     * existing values and keep this value the same.
      * 1 (v6 org) + 1 (v6 react) + 1 (v5 org) + 1 (codemods) + 1 (ai-helpers)
      */
     expect(baseHashes.size).toBe(5);

--- a/src/__tests__/tool.searchPatternFlyDocs.test.ts
+++ b/src/__tests__/tool.searchPatternFlyDocs.test.ts
@@ -31,50 +31,62 @@ describe('searchPatternFlyDocsTool, callback', () => {
   it.each([
     {
       description: 'default',
-      searchQuery: 'Button'
+      searchQuery: 'Button',
+      expected: '# Search results for PatternFly version "v6" and "Button". Showing'
     },
     {
       description: 'with trimmed componentName',
-      searchQuery: ' Button  '
+      searchQuery: ' Button  ',
+      expected: '# Search results for PatternFly version "v6" and " Button  ". Showing'
     },
     {
       description: 'with lower case componentName',
-      searchQuery: 'button'
+      searchQuery: 'button',
+      expected: '# Search results for PatternFly version "v6" and "button". Showing'
     },
     {
       description: 'with upper case componentName',
-      searchQuery: 'BUTTON'
+      searchQuery: 'BUTTON',
+      expected: '# Search results for PatternFly version "v6" and "BUTTON". Showing'
     },
     {
       description: 'with explicit valid version',
       searchQuery: 'Button',
-      version: 'v6'
+      version: 'v6',
+      expected: '# Search results for PatternFly version "v6" and "Button". Showing'
     },
     {
       description: 'with partial componentName',
-      searchQuery: 'ton'
+      searchQuery: 'ton',
+      expected: '# Search results for PatternFly version "v6" and "ton". Showing'
     },
     {
       description: 'with multiple words',
-      searchQuery: 'Button Card Table'
+      searchQuery: 'Button Card Table',
+      expected: '# Search results for PatternFly version "v6" and "Button Card Table". Showing'
     },
     {
       description: 'with made up componentName',
-      searchQuery: 'lorem ipsum dolor sit amet'
+      searchQuery: 'lorem ipsum dolor sit amet',
+      expected: 'No PatternFly resources found matching'
     },
     {
       description: 'with "*" searchQuery all',
-      searchQuery: '*'
+      searchQuery: '*',
+      expected: '# Search results for PatternFly version "v6" and "all" resources. Only showing the first'
     },
     {
       description: 'with "all" searchQuery all',
-      searchQuery: 'ALL'
+      searchQuery: 'ALL',
+      expected: '# Search results for PatternFly version "v6" and "all" resources. Only showing the first'
     }
-  ])('should parse parameters, $description', async ({ searchQuery }) => {
+  ])('should parse parameters, $description', async ({ searchQuery, version, expected }) => {
     const [_name, _schema, callback] = searchPatternFlyDocsTool();
-    const result = await callback({ searchQuery });
+    const updatedParams = version ? { searchQuery, version } : { searchQuery };
+    const result = await callback(updatedParams);
+    const firstLine = result.content[0].text.split('\n')[0];
 
-    expect(result.content[0].text.split('\n')[0]).toMatchSnapshot('search');
+    expect(firstLine).toContain(expected);
   });
 
   it.each([
@@ -97,12 +109,19 @@ describe('searchPatternFlyDocsTool, callback', () => {
       description: 'with non-string searchQuery',
       error: '"searchQuery" must be a string from',
       searchQuery: 123
+    },
+    {
+      description: 'with a non-existent version',
+      error: '"version" must be one of the following values',
+      searchQuery: 'button',
+      version: 'v01'
     }
-  ])('should handle errors, $description', async ({ error, searchQuery }) => {
+  ])('should handle errors, $description', async ({ error, searchQuery, version }) => {
     const [_name, _schema, callback] = searchPatternFlyDocsTool();
+    const updatedParams = version ? { searchQuery, version } : { searchQuery };
 
-    await expect(callback({ searchQuery })).rejects.toThrow(McpError);
-    await expect(callback({ searchQuery })).rejects.toThrow(error);
+    await expect(callback(updatedParams)).rejects.toThrow(McpError);
+    await expect(callback(updatedParams)).rejects.toThrow(error);
   });
 
   it('should have a specific markdown format', async () => {


### PR DESCRIPTION
<!--
PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues for confirmation that the work isn't already in progress.
- Review our [PR contributing guidelines](https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md#pull-requests).
-->
## What is it?
<!-- Summary of changes/additions/commits -->
- docs: add contributor repo skills

### Notes
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->
- adds a general skill with symlinked directories for cursor, claude
- add/update our `docs.json` resource with your agent, while we make the migration over to the docs api

<!-- ## How to test-->
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
<!--
### Unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### E2E test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #21 