### PR TITLE
fix: catch tool registration errors

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,14 @@ const options: PfMcpOptions = {
 const server: PfMcpInstance = await start(options);
 ```
 
+> **Tools-as-plugins**
+> 1. Internally (maintained and built into the server), the MCP tool schemas require Zod. Failure to use Zod, or raw Zod shapes, will result in the MCP tool being logged and skipped during registration.
+> 2. Externally (CLI and embedding), MCP tools-as-plugins can be `JSON`, Zod, or raw Zod shapes.
+>
+> The server attempts to normalize external tools-as-plugins plain JSON schemas to facilitate consumer flexibility.
+>
+> Not sure what "tools-as-plugins" and "raw Zod" mean? [See terminology for full definitions](#terminology).
+
 #### About pinned documentation sources
 
 The documentation catalog `src/docs.json` pins remote resources to specific commit SHAs (or explicit refs) for stability and reproducibility. This avoids unexpected upstream changes from breaking results. The `searchPatternFlyDocs` tool handles these lookups transparently for the user.
@@ -277,6 +285,8 @@ See [examples/](examples/) for more programmatic usage examples.
 
 You can extend the server's capabilities by loading **Tool Plugins** at startup. These plugins run out-of-process in an isolated **Tools Host** to ensure security and stability.
 
+> While we recommend using `createMcpTool` for automatic normalization, external plugins are purposefully flexible. They can use plain JSON schemas for `inputSchema`, and the server will handle the conversion to Zod automatically during the loading process.
+
 ### Tool plugin runtime requirements
 
 - **Node.js >= 22**: Loading external tool plugins (`--tool`) requires Node.js version 22 or higher due to the use of advanced process isolation and ESM module loading features.
@@ -291,13 +301,6 @@ The server provides two isolation modes for external plugins via the `--plugin-i
 - **`none`**: The plugin has full access to the system environment, including the filesystem and network, inherited from the host process. Use this mode ONLY if your tool requires specific system access (e.g., executing Git commands or accessing local files outside the sandbox) and you trust the plugin code.
 
 > **Warning**: Disabling isolation (`--plugin-isolation none`) increases the security risk. Always document the reason for requiring this mode in your tool's documentation.
-
-### Terminology
-
-- **`Tool`**: The low-level tuple format `[name, schema, handler]`.
-- **`Tool Config`**: The authoring object format `{ name, description, inputSchema, handler }`.
-- **`Tool Factory`**: A function wrapper `(options) => Tool` (internal).
-- **`Tool Module`**: The programmatic result of `createMcpTool`, representing a collection of tools.
 
 ### Authoring tools
 
@@ -362,6 +365,17 @@ const inputSchema = z.object({
 ```
 
 See [examples/toolPluginHelloWorld.js](examples/toolPluginHelloWorld.js) for a basic example.
+
+### Terminology
+These terms describe **how tools and their related properties are represented** in code and configuration.
+
+- **`Tool`**: The low-level tuple format `[name, schema, handler]`.
+- **`Tool Config`**: The authoring object format `{ name, description, inputSchema, handler }`.
+- **`Tool Factory`**: A function wrapper `(options) => Tool` (internal).
+- **`Tool Module`**: The programmatic result of `createMcpTool`, representing a collection of tools.
+- **`JSON Schema` (`plain object`)**: A plain object intended as JSON Schema (for example `type`, `properties`, `required`). Converted toward Zod where possible via `jsonSchemaToZod` / `fromJSONSchema`.
+- **`Zod schema`**: A Zod schema instance. Loosely detected with `isZodSchema`.
+- **`Raw Zod shape` (`ZodRawShapeCompat`)**: A **non-empty** plain object whose **values** are Zod schemas; keys are field names. An empty `{}` is **not** a raw Zod shape. Detected with `isZodRawShape`.
 
 ## Initial troubleshooting
 

--- a/src/__tests__/__snapshots__/server.test.ts.snap
+++ b/src/__tests__/__snapshots__/server.test.ts.snap
@@ -389,9 +389,6 @@ exports[`runServer should attempt to run server, register a tool: diagnostics 1`
     [
       "Built-in tool at index 0 is missing the static name property, "toolName"",
     ],
-    [
-      "Tool "loremIpsum" has a non Zod inputSchema. This may cause unexpected issues.",
-    ],
   ],
   "hasDebugLogs": true,
   "mcpServer": [
@@ -478,12 +475,6 @@ exports[`runServer should attempt to run server, register multiple tools: diagno
     ],
     [
       "Built-in tool at index 1 is missing the static name property, "toolName"",
-    ],
-    [
-      "Tool "loremIpsum" has a non Zod inputSchema. This may cause unexpected issues.",
-    ],
-    [
-      "Tool "dolorSit" has a non Zod inputSchema. This may cause unexpected issues.",
     ],
   ],
   "hasDebugLogs": true,

--- a/src/__tests__/__snapshots__/server.tools.test.ts.snap
+++ b/src/__tests__/__snapshots__/server.tools.test.ts.snap
@@ -462,7 +462,23 @@ exports[`makeProxyCreators should attempt to invoke a creator then throw an erro
 ]
 `;
 
-exports[`makeProxyCreators should attempt to return proxy creators, a function wrapper per tool, basic 1`] = `
+exports[`makeProxyCreators should attempt to return proxy creators, a function wrapper per tool, JSON schema 1`] = `
+{
+  "debug": [],
+  "output": [
+    [
+      "Lorem Ipsum",
+      {
+        "description": "Lorem ipsum dolor sit amet",
+        "inputSchema": "isZod = true",
+      },
+      [Function],
+    ],
+  ],
+}
+`;
+
+exports[`makeProxyCreators should attempt to return proxy creators, a function wrapper per tool, Zod 1`] = `
 {
   "debug": [],
   "output": [
@@ -489,11 +505,43 @@ exports[`makeProxyCreators should attempt to return proxy creators, a function w
 {
   "debug": [
     [
-      "Tool "Lorem Ipsum" from unknown source failed strict JSON to Zod reconstruction.",
+      "Tool "Dolor Sit" from unknown source failed strict JSON to Zod reconstruction.",
       "Using fallback best effort schema. Review the tool's inputSchema and ensure it is a valid JSON or Zod schema.",
       "[ZOD_SCHEMA: defined: true]",
     ],
   ],
+  "output": [
+    [
+      "Dolor Sit",
+      {
+        "description": "Lorem ipsum dolor sit amet",
+        "inputSchema": "isZod = true",
+      },
+      [Function],
+    ],
+  ],
+}
+`;
+
+exports[`makeProxyCreators should attempt to return proxy creators, a function wrapper per tool, plain object 1`] = `
+{
+  "debug": [],
+  "output": [
+    [
+      "Lorem Ipsum",
+      {
+        "description": "Lorem ipsum dolor sit amet",
+        "inputSchema": "isZod = true",
+      },
+      [Function],
+    ],
+  ],
+}
+`;
+
+exports[`makeProxyCreators should attempt to return proxy creators, a function wrapper per tool, raw Zod 1`] = `
+{
+  "debug": [],
   "output": [
     [
       "Lorem Ipsum",
@@ -511,14 +559,14 @@ exports[`makeProxyCreators should attempt to return proxy creators, a function w
 {
   "debug": [
     [
-      "Tool "Lorem Ipsum" from unknown source failed strict JSON to Zod reconstruction.",
+      "Tool "Amet" from unknown source failed strict JSON to Zod reconstruction.",
       "Using fallback best effort schema. Review the tool's inputSchema and ensure it is a valid JSON or Zod schema.",
       "[ZOD_SCHEMA: defined: true]",
     ],
   ],
   "output": [
     [
-      "Lorem Ipsum",
+      "Amet",
       {
         "description": "Lorem ipsum dolor sit amet",
         "inputSchema": "isZod = true",

--- a/src/__tests__/__snapshots__/server.toolsUser.test.ts.snap
+++ b/src/__tests__/__snapshots__/server.toolsUser.test.ts.snap
@@ -482,3 +482,16 @@ exports[`normalizeTupleSchema should normalize object, valid JSON schema without
   "inputSchema": "isZod = true",
 }
 `;
+
+exports[`normalizeTupleSchema should normalize object, valid Zod schema with description 1`] = `
+{
+  "description": "hello",
+  "inputSchema": "isZod = true",
+}
+`;
+
+exports[`normalizeTupleSchema should normalize object, valid Zod schema without description 1`] = `
+{
+  "inputSchema": "isZod = true",
+}
+`;

--- a/src/__tests__/options.context.test.ts
+++ b/src/__tests__/options.context.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { runServer, type McpTool } from '../server';
@@ -122,7 +123,7 @@ describe('tool creator options context', () => {
 
       return [
         'alsContract',
-        { description: 'Context test tool', inputSchema: {} },
+        { description: 'Context test tool', inputSchema: z.object({}) },
         callback
       ];
     };

--- a/src/__tests__/server.schema.test.ts
+++ b/src/__tests__/server.schema.test.ts
@@ -315,6 +315,35 @@ describe('normalizeInputSchema', () => {
 
     expect(isZodSchema(result)).toBe(false);
   });
+
+  it.each([
+    {
+      description: 'pass through',
+      input: 'not-a-schema',
+      params: {},
+      expected: 'not-a-schema'
+    },
+    {
+      description: 'returnUndefined set',
+      input: 'not-a-schema',
+      params: {
+        returnUndefined: false
+      },
+      expected: 'not-a-schema'
+    },
+    {
+      description: 'returnUndefined, undefined',
+      input: 'not-a-schema',
+      params: {
+        returnUndefined: true
+      },
+      expected: undefined
+    }
+  ])('should return undefined when specified, $description', ({ input, params, expected }) => {
+    const result = normalizeInputSchema(input, { ...params });
+
+    expect(result).toBe(expected);
+  });
 });
 
 describe('zodToJsonSchema', () => {

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { runServer } from '../server';
@@ -112,7 +113,7 @@ describe('runServer', () => {
       tools: [
         jest.fn().mockReturnValue([
           'loremIpsum',
-          { description: 'Lorem Ipsum', inputSchema: {} },
+          { description: 'Lorem Ipsum', inputSchema: z.object({}) },
           jest.fn()
         ])
       ],
@@ -124,12 +125,12 @@ describe('runServer', () => {
       tools: [
         jest.fn().mockReturnValue([
           'loremIpsum',
-          { description: 'Lorem Ipsum', inputSchema: {} },
+          { description: 'Lorem Ipsum', inputSchema: z.object({}) },
           jest.fn()
         ]),
         jest.fn().mockReturnValue([
           'dolorSit',
-          { description: 'Dolor Sit', inputSchema: {} },
+          { description: 'Dolor Sit', inputSchema: z.object({}) },
           jest.fn()
         ])
       ],
@@ -177,6 +178,31 @@ describe('runServer', () => {
     }).toMatchSnapshot('diagnostics');
 
     // Clean up: stop the server to prevent cache pollution
+    await serverInstance.stop();
+  });
+
+  it('should skip registration of internal tools with non-Zod schemas', async () => {
+    const tools = [
+      jest.fn().mockReturnValue([
+        'badTool',
+        { description: 'Bad Tool', inputSchema: {} },
+        jest.fn()
+      ])
+    ];
+
+    const serverInstance = await runServer(
+      { ...DEFAULT_OPTIONS, name: 'test-skip-server' } as any,
+      { tools, allowProcessExit: false }
+    );
+
+    expect(mockServer.registerTool).not.toHaveBeenCalledWith(
+      expect.stringContaining('badTool')
+    );
+
+    expect(MockLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining('has a non Zod inputSchema. Skipping registration.')
+    );
+
     await serverInstance.stop();
   });
 

--- a/src/__tests__/server.tools.test.ts
+++ b/src/__tests__/server.tools.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
+import { z } from 'zod';
 import { log } from '../logger';
 import {
   getBuiltInToolNames,
@@ -323,7 +324,7 @@ describe('makeProxyCreators', () => {
       tools: []
     },
     {
-      description: 'basic',
+      description: 'plain object',
       tools: [
         {
           id: 'loremIpsum',
@@ -335,11 +336,47 @@ describe('makeProxyCreators', () => {
       ]
     },
     {
-      description: 'null JSON input schema',
+      description: 'JSON schema',
       tools: [
         {
           id: 'loremIpsum',
           name: 'Lorem Ipsum',
+          description: 'Lorem ipsum dolor sit amet',
+          inputSchema: { type: 'object', prop: {} },
+          source: ''
+        }
+      ]
+    },
+    {
+      description: 'Zod',
+      tools: [
+        {
+          id: 'loremIpsum',
+          name: 'Lorem Ipsum',
+          description: 'Lorem ipsum dolor sit amet',
+          inputSchema: z.object({}),
+          source: ''
+        }
+      ]
+    },
+    {
+      description: 'raw Zod',
+      tools: [
+        {
+          id: 'loremIpsum',
+          name: 'Lorem Ipsum',
+          description: 'Lorem ipsum dolor sit amet',
+          inputSchema: { prop: z.object({}) },
+          source: ''
+        }
+      ]
+    },
+    {
+      description: 'null JSON input schema',
+      tools: [
+        {
+          id: 'dolorSit',
+          name: 'Dolor Sit',
           description: 'Lorem ipsum dolor sit amet',
           inputSchema: null,
           source: ''
@@ -350,8 +387,8 @@ describe('makeProxyCreators', () => {
       description: 'undefined JSON input schema',
       tools: [
         {
-          id: 'loremIpsum',
-          name: 'Lorem Ipsum',
+          id: 'Amet',
+          name: 'Amet',
           description: 'Lorem ipsum dolor sit amet',
           inputSchema: undefined,
           source: ''
@@ -579,9 +616,9 @@ describe('composeTools', () => {
   const MockLog = jest.mocked(log);
 
   // Mock default creators
-  const loremIpsum = () => ['loremIpsum', { description: 'lorem ipsum', inputSchema: {} }, () => {}];
-  const dolorSitAmet = () => ['dolorSitAmet', { description: 'dolor sit amet', inputSchema: {} }, () => {}];
-  const consecteturAdipiscingElit = () => ['consecteturAdipiscingElit', { description: 'consectetur adipiscing elit', inputSchema: {} }, () => {}];
+  const loremIpsum = () => ['loremIpsum', { description: 'lorem ipsum', inputSchema: z.object({}) }, () => {}];
+  const dolorSitAmet = () => ['dolorSitAmet', { description: 'dolor sit amet', inputSchema: z.object({}) }, () => {}];
+  const consecteturAdipiscingElit = () => ['consecteturAdipiscingElit', { description: 'consectetur adipiscing elit', inputSchema: z.object({}) }, () => {}];
 
   loremIpsum.toolName = 'loremIpsum';
   dolorSitAmet.toolName = 'dolorSitAmet';
@@ -630,7 +667,7 @@ describe('composeTools', () => {
       nodeVersion: 22,
       modules: [
         () => ['lorem', { description: 'lorem ipsum', inputSchema: { type: 'object', properties: {} } }, () => {}],
-        () => ['dolor', { description: 'sit amet', inputSchema: { type: 'object', properties: {} } }, () => {}]
+        () => ['dolor', { description: 'sit amet', inputSchema: z.object({}) }, () => {}]
       ],
       expectedModuleCount: 3
     },
@@ -645,8 +682,8 @@ describe('composeTools', () => {
 
           return testing;
         })(),
-        { name: 'dolor', description: 'sit amet', inputSchema: {}, handler: () => {} },
-        { name: 'dolor', description: 'sit amet', inputSchema: {}, handler: () => {} }
+        { name: 'dolor', description: 'sit amet', inputSchema: z.object({}), handler: () => {} },
+        { name: 'dolor', description: 'sit amet', inputSchema: z.object({}), handler: () => {} }
       ],
       expectedModuleCount: 5
     },
@@ -691,7 +728,7 @@ describe('composeTools', () => {
 
           return testing;
         })(),
-        { name: 'dolor', description: 'sit amet', inputSchema: {}, handler: () => {} },
+        { name: 'dolor', description: 'sit amet', inputSchema: z.object({}), handler: () => {} },
         'file:///test/module.js',
         '@patternfly/tools'
       ],
@@ -701,7 +738,7 @@ describe('composeTools', () => {
       description: 'inline and file package creators duplicate builtin creators',
       nodeVersion: 22,
       modules: [
-        ['loremIpsum', { description: 'lorem ipsum', inputSchema: {} }, () => {}],
+        ['loremIpsum', { description: 'lorem ipsum', inputSchema: z.object({}) }, () => {}],
         'dolorSitAmet'
       ],
       expectedModuleCount: 3
@@ -711,7 +748,7 @@ describe('composeTools', () => {
       nodeVersion: 22,
       modules: [
         { name: '@patternfly/tools', description: 'lorem ipsum', inputSchema: {}, handler: () => {} },
-        { name: 'dolor', description: 'sit amet', inputSchema: {}, handler: () => {} },
+        { name: 'dolor', description: 'sit amet', inputSchema: z.object({}), handler: () => {} },
         'file:///test/module.js',
         '@patternfly/tools',
         'DOLOR   '
@@ -723,7 +760,7 @@ describe('composeTools', () => {
       nodeVersion: 20,
       modules: [
         { name: '@patternfly/tools', description: 'lorem ipsum', inputSchema: {}, handler: () => {} },
-        { name: 'dolor', description: 'sit amet', inputSchema: {}, handler: () => {} },
+        { name: 'dolor', description: 'sit amet', inputSchema: z.object({}), handler: () => {} },
         'file:///test/module.js',
         '@patternfly/tools',
         'DOLOR   '

--- a/src/__tests__/server.toolsUser.test.ts
+++ b/src/__tests__/server.toolsUser.test.ts
@@ -107,6 +107,14 @@ describe('normalizeTupleSchema', () => {
       schema: { inputSchema: { type: 'object', properties: {} } }
     },
     {
+      description: 'valid Zod schema with description',
+      schema: { description: '  hello  ', inputSchema: z.object({}) }
+    },
+    {
+      description: 'valid Zod schema without description',
+      schema: { inputSchema: z.object({}) }
+    },
+    {
       description: 'non-object',
       schema: 'nope'
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,13 +129,13 @@ type PfMcpStatReport = ServerStatReport;
  *   stop();
  * }
  *
- * @example Programmatic: A MCP server with inline tool configuration.
+ * @example Programmatic: A MCP server with inline tool configuration and JSON inputSchema.
  * import { start, createMcpTool } from '@patternfly/patternfly-mcp';
  *
  * const myToolModule = createMcpTool({
  *   name: 'my-tool',
  *   description: 'My tool description',
- *   inputSchema: {},
+ *   inputSchema: { type: 'object', properties: {} },
  *   handler: async (args) => args
  * });
  *

--- a/src/server.schema.ts
+++ b/src/server.schema.ts
@@ -124,9 +124,9 @@ const jsonSchemaToZod = (
  *
  * @param inputSchema - Input schema (Zod schema, ZodRawShapeCompat, or plain JSON Schema)
  * @param settings - Optional settings
- * @param settings.returnUndefined - Return `undefined` instead of the original value.
- * @returns Returns a Zod instance for known inputs such as "Zod schema", "raw shape", or "JSON Schema", or the original value otherwise.
- *     When provided `settings.returnValue` takes precedence over the original value.
+ * @param settings.returnUndefined - When `true`, return `undefined` instead of the original value.
+ * @returns Returns a Zod instance for known inputs (e.g. "Zod schema", "raw shape", or "JSON Schema") or on failure, the original value.
+ *     If `settings.returnUndefined` is provided and `true`, `undefined` is returned on failure.
  */
 const normalizeInputSchema = (
   inputSchema: unknown,

--- a/src/server.schema.ts
+++ b/src/server.schema.ts
@@ -123,9 +123,15 @@ const jsonSchemaToZod = (
  * - If it's a plain JSON Schema, convert it to a Zod schema.
  *
  * @param inputSchema - Input schema (Zod schema, ZodRawShapeCompat, or plain JSON Schema)
+ * @param settings - Optional settings
+ * @param settings.returnUndefined - Return `undefined` instead of the original value.
  * @returns Returns a Zod instance for known inputs such as "Zod schema", "raw shape", or "JSON Schema", or the original value otherwise.
+ *     When provided `settings.returnValue` takes precedence over the original value.
  */
-const normalizeInputSchema = (inputSchema: unknown): z.ZodTypeAny | unknown => {
+const normalizeInputSchema = (
+  inputSchema: unknown,
+  { returnUndefined }: { returnUndefined?: boolean } = {}
+): z.ZodTypeAny | unknown => {
   // If it's already a Zod schema or a ZodRawShapeCompat (object with Zod schemas as values), return as-is
   if (isZodSchema(inputSchema)) {
     return inputSchema;
@@ -138,7 +144,16 @@ const normalizeInputSchema = (inputSchema: unknown): z.ZodTypeAny | unknown => {
 
   // If it's a plain JSON Schema object, convert to Zod
   if (isPlainObject(inputSchema)) {
-    return jsonSchemaToZod(inputSchema);
+    const result = jsonSchemaToZod(inputSchema, { failFast: true });
+
+    if (result) {
+      return result;
+    }
+  }
+
+  // Force a return value
+  if (returnUndefined) {
+    return undefined;
   }
 
   // Fallback: return as-is (might be undefined or other types)

--- a/src/server.tools.ts
+++ b/src/server.tools.ts
@@ -19,7 +19,7 @@ import {
 import { getOptions, getSessionOptions } from './options.context';
 import { setToolOptions } from './options.tools';
 import { normalizeTools, sanitizeStaticToolName, type NormalizedToolEntry } from './server.toolsUser';
-import { jsonSchemaToZod } from './server.schema';
+import { jsonSchemaToZod, normalizeInputSchema } from './server.schema';
 
 /**
  * Handle for a spawned Tools Host process.
@@ -327,6 +327,7 @@ const spawnToolsHost = async (
  * - Parent does not perform validation; the child validates with Zod at invocation.
  * - A minimal Zod inputSchema from the parent is required to trigger the MCP SDK parameter
  *    validation.
+ * - Descriptors from the manifest are JSON. `normalizeInputSchema` is used defensively.
  * - There is an unreachable defensive check in `makeProxyCreators` that ensures the Zod schema
  *    always returns a value.
  * - Invocation errors from the child preserve `error.code` and `error.details` for debugging.
@@ -342,8 +343,8 @@ const makeProxyCreators = (
   const name = tool.name;
   const invokeTimeoutMs = Math.max(0, Number(pluginHost?.invokeTimeoutMs) || 0);
 
-  // Rebuild Zod schema from serialized JSON.
-  const zodSchemaStrict = jsonSchemaToZod(tool.inputSchema);
+  // Rebuild Zod schema from serialized JSON. Defensive use of `normalizeInputSchema` also allows for Zod and raw Zod shapes.
+  const zodSchemaStrict = normalizeInputSchema(tool.inputSchema, { returnUndefined: true });
   let zodSchema = zodSchemaStrict;
 
   // Rebuild Zod schema again for compatibility.

--- a/src/server.ts
+++ b/src/server.ts
@@ -229,7 +229,10 @@ const builtinResources: McpResourceCreator[] = [
  * Create and run the MCP server, register tools, and return a handle.
  *
  *  - Built-in and inline tools are realized in-process
- *  - External plugins are realized in the Tools Host (child).
+ *  - External MCP tools-as-plugins are realized in the Tools Host (child).
+ *  - In-process MCP tools must supply a Zod-shaped `inputSchema` or they will be skipped during registration.
+ *     - Internally (maintained and built into the server), the MCP tool schemas require Zod.
+ *     - Externally (CLI and embedding), MCP tools-as-plugins can be `JSON`, Zod, or raw Zod shapes, and are normalized for convenience.
  *
  * @param [options] Server options
  * @param [settings] Server settings (tools, signal handling, etc.)

--- a/src/server.ts
+++ b/src/server.ts
@@ -386,49 +386,55 @@ const runServer = async (options: ServerOptions = getOptions(), {
       const isZod = isZodSchema(schema?.inputSchema) || isZodRawShape(schema?.inputSchema);
       const isSchemaDefined = schema?.inputSchema !== undefined;
 
-      log.info(`Registered tool: ${name}`);
-
       if (!isZod) {
-        log.warn(`Tool "${name}" has a non Zod inputSchema. This may cause unexpected issues.`);
+        log.warn(`Tool "${name}" has a non Zod inputSchema. Skipping registration.`);
         log.debug(
           `Tool "${name}" has received a non Zod inputSchema from the tool pipeline.`,
           `This will cause unexpected issues, such as failure to pass arguments.`,
           `MCP SDK requires Zod. Kneel before Zod.`
         );
+
+        return;
       }
 
       // Lightweight check for malformed schemas that bypass validation.
       const isContextLike = (value: unknown) => isPlainObject(value) && 'requestId' in value && 'signal' in value;
 
-      server?.registerTool(name, schema, (args: unknown = {}, ..._args: unknown[]) =>
-        runWithSession(session, async () =>
-          runWithOptions(options, async () => {
-            // Basic track for remaining args to account for future MCP SDK alterations.
-            log.debug(
-              `Running tool "${name}"`,
-              `isArgs = ${args !== undefined}`,
-              `isRemainingArgs = ${_args?.length > 0}`
-            );
-
-            const timedReport = stat.traffic();
-            const isContextLikeArgs = isContextLike(args);
-
-            // Log potential Zod validation errors triggered by context fail.
-            if (isContextLikeArgs) {
+      try {
+        server?.registerTool(name, schema, (args: unknown = {}, ..._args: unknown[]) =>
+          runWithSession(session, async () =>
+            runWithOptions(options, async () => {
+              // Basic track for remaining args to account for future MCP SDK alterations.
               log.debug(
-                `Tool "${name}" handler received a context like object as the first parameter.`,
-                'If this is unexpected this is likely an undefined schema or a schema not registering as Zod.',
-                'Review the related schema definition and ensure it is defined and valid.',
-                `Schema is Defined = ${isSchemaDefined}; Schema is Zod = ${isZod}; Context like = ${isContextLikeArgs};`
+                `Running tool "${name}"`,
+                `isArgs = ${args !== undefined}`,
+                `isRemainingArgs = ${_args?.length > 0}`
               );
-            }
 
-            const toolResult = await callback(args);
+              const timedReport = stat.traffic();
+              const isContextLikeArgs = isContextLike(args);
 
-            timedReport({ tool: name });
+              // Log potential Zod validation errors triggered by context fail.
+              if (isContextLikeArgs) {
+                log.debug(
+                  `Tool "${name}" handler received a context like object as the first parameter.`,
+                  'If this is unexpected this is likely an undefined schema or a schema not registering as Zod.',
+                  'Review the related schema definition and ensure it is defined and valid.',
+                  `Schema is Defined = ${isSchemaDefined}; Schema is Zod = ${isZod}; Context like = ${isContextLikeArgs};`
+                );
+              }
 
-            return toolResult;
-          })));
+              const toolResult = await callback(args);
+
+              timedReport({ tool: name });
+
+              return toolResult;
+            })));
+
+        log.info(`Registered tool: ${name}`);
+      } catch (error) {
+        log.error(`Failed to register tool "${name}":`, error);
+      }
     });
 
     if (enableSigint && !sigintHandler) {


### PR DESCRIPTION
<!--
PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues for confirmation that the work isn't already in progress.
- Review our [PR contributing guidelines](https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md#pull-requests).
-->
## What is it?
<!-- Summary of changes/additions/commits -->
- fix: catch tool registration errors
   * docs, add terms, definitions for JSON, Zod, raw Zod
   * index, annotate JSON inputSchema, tools-as-plugins
   * server.schemas, normalizeInputSchema, add setting, allow returning undefined
   * server.tools, makeProxyCreators, use defensive normalizeInputSchema
   * server, try-catch tool registration, skip tools without zod schemas

### Notes
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->
- #154 released a potential breaking change as "fix." patch potential fail point
- this work can go in before or after since it's applying logic
- pf mcp already attempts to convert the json schema to a zod schema (zod released a feature to do this type of conversion) for "tools as plugins". we do not perform this zod conversion for internal tools, it is expected you use a zod/raw zod (zod-like) object. 
   - this is a fallback for one-off scenarios where a non-zod schema manages to get through to registration
   - we now log and skip the tool registration
   - we wrap the registration in a try/catch for a smoother consumer experience
- mcp sdk 1.28.0 still seems to allow a "zod-like" input schema, this may become stricter in the future and would require us to potentially tighten checks more
- work includes a minor refactor and expanded unit testing of the schema normalization logic to support both strict Zod internal tools and flexible JSON-based external plugins.

<!-- ## How to test-->
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
<!--
### Unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### E2E test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing

caused by #154 