### PR TITLE
docs: docs.json, remove update skill references

### DIFF
--- a/guidelines/skills/add-docs-links/SKILL.md
+++ b/guidelines/skills/add-docs-links/SKILL.md
@@ -7,51 +7,52 @@ description: Maintains the PatternFly MCP documentation catalog in src/docs.json
 
 ## When to use
 
-User wants to **add**, **change**, or **remove** entries in `src/docs.json`, or fix broken / unreachable catalog links. They may paste **any GitHub URL** (blob or raw); you convert blob → raw, pick refs, verify reachability, shape entries, update `meta` and `generated`, and run tests.
+User wants to **add**, **change**, or **remove** rows in `src/docs.json`, or fix broken / unreachable catalog links. They may paste **any GitHub URL** (blob or raw); you convert blob → raw, pick refs, verify reachability, shape entries, update `meta` and `generated`, and run tests.
 
-For **editing or removing**: locate the entry by `path` or component key; after changes, recompute `meta.totalEntries`, `meta.totalDocs`, set `generated` to current ISO time, run `npm test`. Same constraints as adds (whitelist, unique `path`, base-hash count).
+For **edits or removals**: find the row by `path` and/or its `docs` key; update `meta` / `generated`; run tests. Same rules as adds: whitelist, unique `path`, and `src/__tests__/docs.json.test.ts` (including `baseHashes`).
 
 ## Workflow
 
-1. **Resolve the raw URL and ref (git hash/branch)**
-   - Decide repo and file path (e.g. `patternfly/patternfly-org`, `patternfly/patternfly-react`).
-   - **Why SHAs:** Pinned commit SHAs keep each `path` immutable until deliberately updated. See [reference.md](reference.md#path-raw-url).
-   - Prefer an **existing ref** already in `docs.json` for that repo (keeps `baseHashes.size === 5` in unit tests). Extract from an existing entry’s `path`.
-   - If a new ref is required: resolve SHA (e.g. GitHub API `GET /repos/{owner}/{repo}/commits?sha={branch}`) or use a stable tag in the raw URL.
+1. **Resolve raw URL and ref**
+   - Map the link to `owner/repo` and file path; build **raw** `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{file}`.
+   - Prefer the **same `ref`** already used in `docs.json` for that `patternfly/<repo>` (copy from an existing `path`).
+   - **New** `patternfly/<repo>`: after you add URLs, `docs.json.test.ts` may need `expect(baseHashes.size)` updated—open that file; do not guess a number from this skill.
+   - New ref for an existing repo: resolve SHA (e.g. commits API) or use a stable tag.
 
-2. **Build the raw URL (must be whitelisted)**
-   - `path` must match the whitelist in `src/options.defaults.ts` (`patternflyOptions.urlWhitelist`). See [reference.md](reference.md#url-whitelist-allowed-domains).
-   - **Maintainer-controlled:** Avoid changing the whitelist; new domains delay review.
-   - Allowed bases: `https://patternfly.org`, `https://github.com/patternfly`, `https://raw.githubusercontent.com/patternfly`. Use **https** for every new URL.
-   - GitHub raw pattern: `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path-to-file}`.
+2. **Whitelist**
+   - `path` must match `patternflyOptions.urlWhitelist` in `src/options.defaults.ts`. See [reference.md](reference.md#url-whitelist-allowed-domains). Use **https** only. Do not widen the whitelist in a catalog-only PR.
 
-3. **Confirm the URL is reachable**
-   - Raw URL must return HTTP 200–299 (e.g. `curl -sI -o /dev/null -w "%{http_code}" "<url>"` or `tests/audit/utils/checkUrl.ts`). If unreachable, fix ref/path or do not add.
+3. **Reachability**
+   - Response must be 2xx (e.g. `curl -sI -o /dev/null -w "%{http_code}" "<url>"`). If not, fix ref or path; do not add a dead link.
 
-4. **Avoid duplicate paths**
-   - Each `path` is unique across the file; `src/__tests__/docs.json.test.ts` fails on duplicates with a clear report. Scan before adding to avoid churn.
+4. **Unique `path`**
+   - Each `path` appears once in the whole file.
 
-5. **Add or update entries**
-   - Full field list and types: [reference.md — Entry format](reference.md#entry-format). Insert under the right PascalCase component key; preserve project ordering (e.g. alphabetical keys) when editing.
+5. **Placement in `docs`**
+   - **New top-level key** under `docs` (e.g. `"AiHelpers"`): append as the **last property** inside `"docs": { … }` (after the current last key’s block). Do not insert mid-file by theme or alphabet.
+   - **New object** in an **existing** key’s array: append to the **end of that array** unless the user specifies order.
+   - **Edits**: keep the same key and array index unless the user asks to move.
 
-6. **Update `meta` and `generated`**
+6. **Entry shape**
+   - Fields and types: [reference.md — Entry format](reference.md#entry-format). Copy `section` / `category` from the closest similar row when unsure.
+
+7. **`meta` and `generated`**
    - `meta.totalEntries` = number of keys in `docs`.
-   - `meta.totalDocs` = total entries across all arrays.
-   - `generated` = current ISO timestamp (`new Date().toISOString()`).
+   - `meta.totalDocs` = total objects across all arrays.
+   - `generated` = `new Date().toISOString()`.
 
-7. **Run unit tests and snapshots**
-   - From repo root: `npm test` (or `jest --selectProjects unit --roots=src/`).
-   - `docs.json.test.ts` validates duplicates, `meta`, and base-hash count. Coordinate before changing the expected base-hash count.
-   - If snapshots fail after catalog changes, update them intentionally—common: `src/__tests__/docs.embedded.test.ts` (`EMBEDDED_DOCS`), and tool/resource tests under `src/__tests__/` that snapshot docs-derived output (e.g. `tool.patternFlyDocs.test.ts`, `tool.searchPatternFlyDocs.test.ts`, `resource.patternFlyDocs*.test.ts`). Use the project’s usual Jest update flow (e.g. `npm test -- -u` scoped to the failing file).
+8. **Tests**
+   - From repo root: `npm test` or `jest --selectProjects unit --roots=src/`.
+   - If snapshots fail, update only where the catalog drives output (`docs.embedded`, `tool.patternFly*`, `resource.patternFlyDocs*`), e.g. scoped `npm test -- -u path/to/file.test.ts`.
 
-**CI:** `.github/workflows/audit.yml` runs on PRs touching `src/docs.json` or `tests/audit/**` and samples links for reachability (`tests/audit/`).
+**CI:** `.github/workflows/audit.yml` on PRs that touch `src/docs.json` or `tests/audit/**`.
 
 ## Quick checks
 
-- [ ] Blob URLs converted to raw; ref reused from `docs.json` when possible.
-- [ ] `path` is whitelisted and uses `https`.
-- [ ] Raw URL returns 2xx.
-- [ ] No duplicate `path` values.
-- [ ] Entry shape matches [reference.md](reference.md#entry-format); correct PascalCase key.
-- [ ] `meta.totalEntries`, `meta.totalDocs`, and `generated` updated.
-- [ ] `npm test` passes; snapshots updated only where catalog-driven output changed.
+- [ ] Blob → raw; ref reused per repo when possible.
+- [ ] `path` whitelisted, **https**, 2xx.
+- [ ] No duplicate `path`.
+- [ ] New **keys** at **end** of `docs`; new **array rows** at **end** of the target array.
+- [ ] `meta` and `generated` updated.
+- [ ] New `patternfly/<repo>`: `docs.json.test.ts` `baseHashes` expectation still matches.
+- [ ] Tests pass; snapshots updated only if catalog-driven output changed.

--- a/guidelines/skills/add-docs-links/reference.md
+++ b/guidelines/skills/add-docs-links/reference.md
@@ -4,12 +4,12 @@
 
 - Catalog: `src/docs.json`
 - Unit test: `src/__tests__/docs.json.test.ts`
-- Link audit: `tests/audit/docs.audit.test.ts` (samples links and checks reachability)
-- **CI:** `.github/workflows/audit.yml` runs a daily audit (and on PRs that change `src/docs.json` or `tests/audit/**`), executing the audit tests so links in `docs.json` are periodically checked for reachability.
+- Link audit: `tests/audit/docs.audit.test.ts`
+- CI: `.github/workflows/audit.yml` (daily + PRs that touch `src/docs.json` or `tests/audit/**`)
 
 ## Top-level structure
 
-Illustrative shape only—**do not copy** `generated`, `meta.totalEntries`, or `meta.totalDocs` from this block; those must always match the real `src/docs.json` after your edit (and `meta` is validated by unit tests).
+Illustrative only—**do not copy** `generated`, `meta.totalEntries`, or `meta.totalDocs` from examples; recompute from the real file after edits.
 
 ```json
 {
@@ -26,13 +26,13 @@ Illustrative shape only—**do not copy** `generated`, `meta.totalEntries`, or `
 }
 ```
 
-- `meta.totalEntries`: number of keys in `docs` (component count).
-- `meta.totalDocs`: total number of doc entries across all keys.
-- `docs`: keys are PascalCase component names; values are arrays of entry objects.
+- `meta.totalEntries`: count of keys in `docs`.
+- `meta.totalDocs`: sum of array lengths under `docs`.
+- `docs`: string keys → arrays of entry objects.
 
 ## Entry format
 
-Each entry in `docs.<ComponentName>[]`:
+Each object in `docs.<Key>[]`:
 
 | Field         | Type   | Example |
 |---------------|--------|---------|
@@ -40,7 +40,7 @@ Each entry in `docs.<ComponentName>[]`:
 | `description` | string | `"Design Guidelines for the about modal component."` |
 | `pathSlug`    | string | `"about-modal"` |
 | `section`     | string | `"components"` |
-| `category`    | string | Match sibling entries in `docs.json` for the same kind of doc (e.g. `design-guidelines`, `react`, `accessibility`); the catalog uses additional values—copy an existing entry’s `category` when unsure. |
+| `category`    | string | Reuse the same `category` as similar rows (e.g. `design-guidelines`, `react`, `accessibility`). |
 | `source`      | string | `"github"` |
 | `path`        | string | Full raw GitHub URL (see below) |
 | `version`     | string | `"v6"` \| `"v5"` |
@@ -48,40 +48,33 @@ Each entry in `docs.<ComponentName>[]`:
 ### path (raw URL)
 
 - Pattern: `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path-to-file}`
-- `ref`: branch name, tag (e.g. `v5`), or **commit SHA** (preferred for v6 org/react-style links).
+- `ref`: branch, tag (e.g. `v5`), or **SHA** (preferred for moving upstream trees).
 
-**Why commit SHAs are used (instead of only `main` / a moving branch):** A pinned SHA makes the fetched doc **immutable** for that URL: the catalog always resolves to the same file content until someone intentionally updates the ref. Branch heads change as upstream merges; without a pin, links could silently point at different text, break if files move, or make audits and support harder to reason about. Tags (e.g. `v5`) can also pin a release line; the project still limits how many distinct refs it tracks (see unit test `baseHashes`).
+**Pinned refs:** A SHA (or stable tag) fixes content for that URL until you bump it deliberately. Moving branch heads can change or break files without notice.
+
+**`baseHashes`:** The test counts distinct ref segments per `patternfly/<repo>` on raw URLs. The allowed total is **only** in `src/__tests__/docs.json.test.ts` (`baseHashes`, `expect(baseHashes.size)`). Reuse an existing ref per repo when you can; if you add a **new** `patternfly/<repo>`, update that test and mention it in the PR.
 
 - Example: `https://raw.githubusercontent.com/patternfly/patternfly-org/2d5fec39ddb8aa32ce78c9a63cdfc1653692b193/packages/documentation-site/patternfly-docs/content/components/about-modal/about-modal.md`
-- **Must be whitelisted:** see [URL whitelist](#url-whitelist-allowed-domains) below.
+- **Whitelist:** [URL whitelist](#url-whitelist-allowed-domains) below.
 
 ## URL whitelist (allowed domains)
 
-External paths and references are limited by a PatternFly URL whitelist so the server only fetches from allowed origins.
+Defined in `src/options.defaults.ts` → `patternflyOptions.urlWhitelist`. Used when validating/fetching paths.
 
-- **Defined in:** `src/options.defaults.ts` → `PATTERNFLY_OPTIONS` → `patternflyOptions.urlWhitelist`
-- **Used by:** `tool.patternFlyDocs` (validates `urlList` via `assertInputUrlWhiteListed`); matching logic in `server.helpers.ts` → `isWhitelistedUrl`.
-- **Default entries (prefix match):**
-  - `https://patternfly.org` — patternfly.org and subdomains (e.g. `www.patternfly.org`, `v6.docs.patternfly.org`)
-  - `https://github.com/patternfly` — any path under `github.com/patternfly`
-  - `https://raw.githubusercontent.com/patternfly` — any path under `raw.githubusercontent.com/patternfly` (e.g. `patternfly-org`, `patternfly-react`)
-- **Protocols:** `urlWhitelistProtocols` may include both `http` and `https` in server configuration. **For `docs.json`:** always use `https://` URLs only; do not add new `http://` catalog paths.
+- **Prefixes:** `https://patternfly.org`, `https://github.com/patternfly`, `https://raw.githubusercontent.com/patternfly`
+- **`docs.json`:** use **https** only.
 
-Any new `path` in `docs.json` must match one of these prefixes (protocol + host + path prefix). URLs that do not match will be rejected when the tool is used with a `urlList` or when the server fetches by path.
-
-**Maintainer-controlled:** The whitelist is controlled at the maintainer level. It is recommended to avoid updating it; if it is modified, your contribution will be delayed while the new whitelisted domain is reviewed.
+Paths must match a prefix or the server rejects them. Avoid widening the whitelist in catalog-only PRs.
 
 ## Duplicate check
 
-- Every `path` in the file must be **unique** across all entries.
-- **Automatically enforced by unit test:** `src/__tests__/docs.json.test.ts` builds a map of each `path` to the list of entries that use it; if any path has more than one entry, the test fails and reports each duplicate path and which component/category entries reference it. Run `npm test` to confirm no duplicates. Optionally, before adding an entry, collect all `path` values (e.g. `Object.values(docs.docs).flat().map(e => e.path)`) to avoid a failing test.
+Each `path` is unique file-wide. `docs.json.test.ts` fails with a duplicate report if not.
 
 ## GitHub ref (hash) lookup
 
-- **Use existing refs**: Prefer the ref already used in `docs.json` for that repo (same owner/repo). Extract the ref from an existing `path`: the segment after `raw.githubusercontent.com/owner/repo/` and before the next `/`.
-- **New ref via API**: For branch `main` of `patternfly/patternfly-org`:
-  - `GET https://api.github.com/repos/patternfly/patternfly-org/commits/main` (or `commits?sha=main`) and use the response `sha` in the raw URL.
-- **Confirm raw URL**: After building the URL, fetch it (e.g. `curl -sI` or the project’s `checkUrl`) and ensure HTTP 200–299.
+- **Reuse ref:** For the same `patternfly/<repo>`, copy the `ref` segment from an existing catalog `path` (text between `…/repo/` and the next `/`).
+- **Resolve SHA:** e.g. `GET https://api.github.com/repos/patternfly/patternfly-org/commits/main` → use returned `sha` in the raw URL.
+- **Verify:** 2xx on the final raw URL before merging.
 
 ## Unit test constraints
 
@@ -89,8 +82,8 @@ From `src/__tests__/docs.json.test.ts`:
 
 1. No duplicate `path` values.
 2. `meta.totalEntries` === number of keys in `docs`.
-3. `meta.totalDocs` === total number of entries in all arrays.
-4. Number of unique “base hashes” (refs per repo) is **5** (v6 org, v6 react, v5 org, codemods, ai-helpers). When adding links, use existing refs so this count does not change unless the project explicitly adds a new source.
+3. `meta.totalDocs` === total entries in all arrays.
+4. **`baseHashes`:** see `path (raw URL)` above—single source of truth is that test file.
 
 ## Example new entry
 
@@ -107,4 +100,4 @@ From `src/__tests__/docs.json.test.ts`:
 }
 ```
 
-Place under `docs["NewComponent"]` (or the correct PascalCase key); create the key if it does not exist.
+Add under `docs["NewComponent"]` (or the correct key). **New top-level keys** go **last** inside `docs` (see SKILL workflow step 5).


### PR DESCRIPTION


<!--
PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues for confirmation that the work isn't already in progress.
- Review our [PR contributing guidelines](https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md#pull-requests).
-->
## What is it?
- docs: docs.json, remove update skill references

### Notes
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->
- skill indicated it needed to update the skill, cleaned up to focus on the related unit test and be more concise

<!-- ## How to test-->
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
<!--
### Unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### E2E test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #166 #165 
ongoing