### PR TITLE
chore: add PF Team label workflow

### DIFF
--- a/.github/workflows/label-pf-team-issues.yml
+++ b/.github/workflows/label-pf-team-issues.yml
@@ -1,0 +1,14 @@
+name: Label PF Team issues
+
+permissions:
+  contents: read
+  issues: write
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label:
+    uses: patternfly/.github/.github/workflows/add-pf-team-label-workflow.yml@main
+    secrets: inherit


### PR DESCRIPTION
Made-with: Cursor

This adds a github action to leverage the common workflow to add the pf team label to any issues opened by the pf team for the sake of backlog organization and management.