### PR TITLE
feat: add dynamic ai-helpers skill fetching from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 build/
 *.tsbuildinfo
 
+# Runtime cache
+.cache/
+
 # Environment variables
 .env
 .env.local

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,6 +1,7 @@
 {
   "language": "en",
   "words": [
+    "aihelpers",
     "amet",
     "codemods",
     "ized",
@@ -12,6 +13,7 @@
     "onsessioninitialized",
     "onsessionclosed",
     "patternfly",
+    "prerendered",
     "rereview",
     "rsort",
     "sparkline",

--- a/src/__tests__/__snapshots__/server.test.ts.snap
+++ b/src/__tests__/__snapshots__/server.test.ts.snap
@@ -43,10 +43,19 @@ exports[`runServer should allow server to be stopped, http stop server: diagnost
       "Registered resource: patternfly-schemas-template",
     ],
     [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
+    ],
+    [
       "Registered tool: usePatternFlyDocs",
     ],
     [
       "Registered tool: searchPatternFlyDocs",
+    ],
+    [
+      "Registered tool: useAiHelpersSkill",
     ],
     [
       "test-server server running on HTTP transport",
@@ -105,10 +114,19 @@ exports[`runServer should allow server to be stopped, stdio stop server: diagnos
       "Registered resource: patternfly-schemas-template",
     ],
     [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
+    ],
+    [
       "Registered tool: usePatternFlyDocs",
     ],
     [
       "Registered tool: searchPatternFlyDocs",
+    ],
+    [
+      "Registered tool: useAiHelpersSkill",
     ],
     [
       "test-server server running on stdio transport",
@@ -165,6 +183,12 @@ exports[`runServer should attempt to run server, create transport, connect, and 
     ],
     [
       "Registered resource: patternfly-schemas-template",
+    ],
+    [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
     ],
     [
       "test-server-4 server running on stdio transport",
@@ -240,6 +264,12 @@ exports[`runServer should attempt to run server, disable SIGINT handler: diagnos
       "Registered resource: patternfly-schemas-template",
     ],
     [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
+    ],
+    [
       "test-server-7 server running on stdio transport",
     ],
   ],
@@ -306,6 +336,12 @@ exports[`runServer should attempt to run server, enable SIGINT handler explicitl
     ],
     [
       "Registered resource: patternfly-schemas-template",
+    ],
+    [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
     ],
     [
       "test-server-8 server running on stdio transport",
@@ -379,6 +415,12 @@ exports[`runServer should attempt to run server, register a tool: diagnostics 1`
     ],
     [
       "Registered resource: patternfly-schemas-template",
+    ],
+    [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
     ],
     [
       "Registered tool: loremIpsum",
@@ -460,6 +502,12 @@ exports[`runServer should attempt to run server, register multiple tools: diagno
     ],
     [
       "Registered resource: patternfly-schemas-template",
+    ],
+    [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
     ],
     [
       "Registered tool: loremIpsum",
@@ -550,6 +598,12 @@ exports[`runServer should attempt to run server, use custom options: diagnostics
       "Registered resource: patternfly-schemas-template",
     ],
     [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
+    ],
+    [
       "test-server-3 server running on stdio transport",
     ],
   ],
@@ -623,10 +677,19 @@ exports[`runServer should attempt to run server, use default tools, http: diagno
       "Registered resource: patternfly-schemas-template",
     ],
     [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
+    ],
+    [
       "Registered tool: usePatternFlyDocs",
     ],
     [
       "Registered tool: searchPatternFlyDocs",
+    ],
+    [
+      "Registered tool: useAiHelpersSkill",
     ],
     [
       "test-server-2 server running on HTTP transport",
@@ -658,6 +721,7 @@ exports[`runServer should attempt to run server, use default tools, http: diagno
   "registerTool": [
     "usePatternFlyDocs",
     "searchPatternFlyDocs",
+    "useAiHelpersSkill",
   ],
 }
 `;
@@ -705,10 +769,19 @@ exports[`runServer should attempt to run server, use default tools, stdio: diagn
       "Registered resource: patternfly-schemas-template",
     ],
     [
+      "Registered resource: aihelpers-skills-index",
+    ],
+    [
+      "Registered resource: aihelpers-skills-template",
+    ],
+    [
       "Registered tool: usePatternFlyDocs",
     ],
     [
       "Registered tool: searchPatternFlyDocs",
+    ],
+    [
+      "Registered tool: useAiHelpersSkill",
     ],
     [
       "test-server-1 server running on stdio transport",
@@ -740,6 +813,7 @@ exports[`runServer should attempt to run server, use default tools, stdio: diagn
   "registerTool": [
     "usePatternFlyDocs",
     "searchPatternFlyDocs",
+    "useAiHelpersSkill",
   ],
 }
 `;

--- a/src/aiHelpers.skills.ts
+++ b/src/aiHelpers.skills.ts
@@ -1,0 +1,129 @@
+import { resolve, dirname } from 'node:path';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { memo } from './server.caching';
+import { log } from './logger';
+
+interface AiHelpersSkill {
+  name: string;
+  plugin: string;
+  description: string;
+  content: string;
+}
+
+interface AiHelpersSkillsData {
+  version: string;
+  generated: string;
+  meta: {
+    totalSkills: number;
+    source: string;
+  };
+  skills: AiHelpersSkill[];
+}
+
+const SKILLS_URL = 'https://raw.githubusercontent.com/patternfly/ai-helpers/main/dist/skills.json';
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+const CACHE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', '.cache');
+
+const CACHE_FILE = resolve(CACHE_DIR, 'aiHelpers.skills.json');
+
+const isValidSkillsData = (data: unknown): data is AiHelpersSkillsData =>
+  Boolean(data) && typeof data === 'object' && Array.isArray((data as AiHelpersSkillsData).skills);
+
+const readCachedSkills = async (): Promise<AiHelpersSkillsData | undefined> => {
+  try {
+    const raw = await readFile(CACHE_FILE, 'utf-8');
+    const data = JSON.parse(raw);
+
+    if (isValidSkillsData(data)) {
+      return data;
+    }
+  } catch {
+    // No cache file or invalid — expected on first run
+  }
+
+  return undefined;
+};
+
+const writeCachedSkills = async (data: AiHelpersSkillsData): Promise<void> => {
+  try {
+    await mkdir(CACHE_DIR, { recursive: true });
+    await writeFile(CACHE_FILE, JSON.stringify(data), 'utf-8');
+  } catch (error) {
+    log.warn(`Failed to write skills cache: ${error instanceof Error ? error.message : error}`);
+  }
+};
+
+const fetchSkillsData = async (): Promise<AiHelpersSkillsData> => {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(SKILLS_URL, { signal: controller.signal });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const data = await response.json() as AiHelpersSkillsData;
+
+    if (!isValidSkillsData(data)) {
+      throw new Error('Invalid skills data shape');
+    }
+
+    log.info(`Loaded ${data.skills.length} ai-helpers skills from GitHub (generated ${data.generated})`);
+
+    await writeCachedSkills(data);
+
+    return data;
+  } catch (error) {
+    log.warn(`Failed to fetch ai-helpers skills from GitHub: ${error instanceof Error ? error.message : error}`);
+
+    const cached = await readCachedSkills();
+
+    if (cached) {
+      log.info(`Using cached skills data (generated ${cached.generated})`);
+
+      return cached;
+    }
+
+    log.warn('No cached skills available — skills will be empty until GitHub is reachable');
+
+    return { version: '0', generated: '', meta: { totalSkills: 0, source: 'none' }, skills: [] };
+  }
+};
+
+const fetchSkillsDataMemo = memo(fetchSkillsData, {
+  cacheLimit: 1,
+  expire: 5 * 60 * 1000,
+  cacheErrors: false
+});
+
+/**
+ * Returns all ai-helpers skills, fetched from GitHub with disk cache fallback.
+ */
+const getAiHelpersSkills = async (): Promise<AiHelpersSkill[]> => {
+  const data = await fetchSkillsDataMemo();
+
+  return data.skills;
+};
+
+/**
+ * Returns the full SKILL.md content for a given skill name.
+ *
+ * @param name - The skill name to look up.
+ */
+const getAiHelpersSkillContent = async (name: string): Promise<string | undefined> => {
+  const data = await fetchSkillsDataMemo();
+  const skill = data.skills.find(
+    (entry: AiHelpersSkill) => entry.name.toLowerCase() === name.toLowerCase()
+  );
+
+  return skill?.content;
+};
+
+export { getAiHelpersSkills, getAiHelpersSkillContent, type AiHelpersSkill };

--- a/src/resource.aiHelpersSkillsIndex.ts
+++ b/src/resource.aiHelpersSkillsIndex.ts
@@ -1,0 +1,59 @@
+import { type McpResource } from './server';
+import { stringJoin } from './server.helpers';
+import { getAiHelpersSkills } from './aiHelpers.skills';
+
+/**
+ * Name of the resource.
+ */
+const NAME = 'aihelpers-skills-index';
+
+/**
+ * URI for the resource.
+ */
+const URI = 'aihelpers://skills/index';
+
+/**
+ * Resource configuration.
+ */
+const CONFIG = {
+  title: 'ai-helpers Skills Index',
+  description: 'Lists all available ai-helpers skills with names and descriptions.',
+  mimeType: 'text/markdown' as const
+};
+
+/**
+ * Resource creator for the ai-helpers skills index.
+ */
+const aiHelpersSkillsIndexResource = (): McpResource => [
+  NAME,
+  URI,
+  CONFIG,
+  async (passedUri: URL) => {
+    const skills = await getAiHelpersSkills();
+
+    const header = stringJoin.newline(
+      '# ai-helpers Skills',
+      '',
+      'PatternFly coding skills served from the [ai-helpers](https://github.com/patternfly/ai-helpers) marketplace. Read any skill via `aihelpers://skills/{name}`.',
+      ''
+    );
+
+    const table = stringJoin.newline(
+      '| Skill | Plugin | Description |',
+      '|-------|--------|-------------|',
+      ...skills.map(skill => `| ${skill.name} | ${skill.plugin} | ${skill.description} |`)
+    );
+
+    return {
+      contents: [
+        {
+          uri: passedUri?.toString(),
+          mimeType: 'text/markdown',
+          text: stringJoin.newline(header, table)
+        }
+      ]
+    };
+  }
+];
+
+export { aiHelpersSkillsIndexResource, NAME, URI, CONFIG };

--- a/src/resource.aiHelpersSkillsTemplate.ts
+++ b/src/resource.aiHelpersSkillsTemplate.ts
@@ -1,0 +1,110 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { type McpResource, type McpResourceMetadata } from './server';
+import { memo } from './server.caching';
+import { assertInputStringLength } from './server.assertions';
+import { getOptions } from './options.context';
+import { getAiHelpersSkills, getAiHelpersSkillContent } from './aiHelpers.skills';
+
+/**
+ * Name of the resource template.
+ */
+const NAME = 'aihelpers-skills-template';
+
+/**
+ * URI template for the resource.
+ */
+const URI_TEMPLATE = 'aihelpers://skills/{name}';
+
+/**
+ * Resource configuration.
+ */
+const CONFIG = {
+  title: 'ai-helpers Skill',
+  description: `Retrieve the full content of a specific ai-helpers skill by name. ${URI_TEMPLATE}`,
+  mimeType: 'text/markdown' as const
+};
+
+/**
+ * Name completion callback for the URI template.
+ *
+ * @param value - The partial name to match against.
+ */
+const uriNameComplete = async (value: string) => {
+  const skills = await getAiHelpersSkills();
+  const lower = (value || '').toLowerCase();
+
+  return skills
+    .map(skill => skill.name)
+    .filter(name => name.toLowerCase().includes(lower))
+    .sort();
+};
+
+uriNameComplete.memo = memo(uriNameComplete);
+
+/**
+ * Resource callback.
+ *
+ * @param passedUri - The resolved URI for this resource request.
+ * @param variables - The URI template variables extracted from the request.
+ * @param options - Server options (defaults to current context options).
+ */
+const resourceCallback = async (passedUri: URL, variables: Record<string, string | string[]>, options = getOptions()) => {
+  const { name } = variables || {};
+
+  assertInputStringLength(name, {
+    ...options.minMax.inputStrings,
+    inputDisplayName: 'name'
+  });
+
+  const skillName = Array.isArray(name) ? name[0] : name;
+  const content = await getAiHelpersSkillContent(skillName);
+
+  if (!content) {
+    return {
+      contents: [
+        {
+          uri: passedUri?.toString(),
+          mimeType: 'text/markdown',
+          text: `Skill "${skillName}" not found. Use \`aihelpers://skills/index\` to list available skills.`
+        }
+      ]
+    };
+  }
+
+  return {
+    contents: [
+      {
+        uri: passedUri?.toString(),
+        mimeType: 'text/markdown',
+        text: content
+      }
+    ]
+  };
+};
+
+/**
+ * Metadata for the resource.
+ */
+const METADATA: McpResourceMetadata = {
+  complete: {
+    name: uriNameComplete.memo
+  }
+};
+
+/**
+ * Resource creator for individual ai-helpers skills.
+ */
+const aiHelpersSkillsTemplateResource = (): McpResource => [
+  NAME,
+  new ResourceTemplate(URI_TEMPLATE, {
+    list: undefined,
+    complete: {
+      name: uriNameComplete.memo
+    }
+  }),
+  CONFIG,
+  resourceCallback,
+  METADATA
+];
+
+export { aiHelpersSkillsTemplateResource, NAME, URI_TEMPLATE, CONFIG };

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,9 @@ import { patternFlyDocsIndexResource } from './resource.patternFlyDocsIndex';
 import { patternFlyDocsTemplateResource } from './resource.patternFlyDocsTemplate';
 import { patternFlySchemasIndexResource } from './resource.patternFlySchemasIndex';
 import { patternFlySchemasTemplateResource } from './resource.patternFlySchemasTemplate';
+import { aiHelpersSkillsIndexResource } from './resource.aiHelpersSkillsIndex';
+import { aiHelpersSkillsTemplateResource } from './resource.aiHelpersSkillsTemplate';
+import { useAiHelpersSkillTool } from './tool.aiHelpersSkills';
 import { startHttpTransport, type HttpServerHandle } from './server.http';
 import { memo } from './server.caching';
 import { log, type LogEvent } from './logger';
@@ -208,7 +211,8 @@ interface ServerInstance {
  */
 const builtinTools: McpToolCreator[] = [
   usePatternFlyDocsTool,
-  searchPatternFlyDocsTool
+  searchPatternFlyDocsTool,
+  useAiHelpersSkillTool
 ];
 
 /**
@@ -222,7 +226,9 @@ const builtinResources: McpResourceCreator[] = [
   patternFlyDocsIndexResource,
   patternFlyDocsTemplateResource,
   patternFlySchemasIndexResource,
-  patternFlySchemasTemplateResource
+  patternFlySchemasTemplateResource,
+  aiHelpersSkillsIndexResource,
+  aiHelpersSkillsTemplateResource
 ];
 
 /**

--- a/src/tool.aiHelpersSkills.ts
+++ b/src/tool.aiHelpersSkills.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import { type McpTool } from './server';
+import { getOptions } from './options.context';
+import { getAiHelpersSkills, getAiHelpersSkillContent } from './aiHelpers.skills';
+import { stringJoin } from './server.helpers';
+
+/**
+ * useAiHelpersSkill tool function.
+ *
+ * @param options
+ * @returns MCP tool tuple [name, schema, callback]
+ */
+const useAiHelpersSkillTool = (options = getOptions()): McpTool => {
+  const callback = async (args: any = {}) => {
+    const { name } = args;
+
+    if (!name) {
+      const skills = await getAiHelpersSkills();
+      const text = stringJoin.newline(
+        '# ai-helpers Skills',
+        '',
+        `${skills.length} skills available. Pass a skill name to retrieve its full content.`,
+        '',
+        '| Skill | Plugin | Description |',
+        '|-------|--------|-------------|',
+        ...skills.map(skill => `| ${skill.name} | ${skill.plugin} | ${skill.description} |`)
+      );
+
+      return { content: [{ type: 'text', text }] };
+    }
+
+    const content = await getAiHelpersSkillContent(name);
+
+    if (!content) {
+      const skills = await getAiHelpersSkills();
+      const suggestions = skills
+        .filter(skill => skill.name.toLowerCase().includes(name.toLowerCase()))
+        .map(skill => skill.name);
+      const text = suggestions.length
+        ? `Skill "${name}" not found. Did you mean: ${suggestions.join(', ')}?`
+        : `Skill "${name}" not found. Use this tool without a name to list all available skills.`;
+
+      return { content: [{ type: 'text', text }] };
+    }
+
+    return { content: [{ type: 'text', text: content }] };
+  };
+
+  return [
+    'useAiHelpersSkill',
+    {
+      description: 'Look up coding skills for PatternFly React development, testing, accessibility, and design foundations. Call without arguments to list all available skills, or pass a skill name to get full instructions.',
+      inputSchema: {
+        name: z.string()
+          .max(options.minMax.inputStrings.max)
+          .optional()
+          .describe('Skill name to retrieve (e.g. "pf-unit-test-generator"). Omit to list all skills.')
+      }
+    },
+    callback
+  ];
+};
+
+/**
+ * A tool name, typically the first entry in the tuple. Used in logging and deduplication.
+ */
+useAiHelpersSkillTool.toolName = 'useAiHelpersSkill';
+
+export { useAiHelpersSkillTool };

--- a/tests/e2e/__snapshots__/httpTransport.test.ts.snap
+++ b/tests/e2e/__snapshots__/httpTransport.test.ts.snap
@@ -69,6 +69,16 @@ Use these parameters to filter the list of PatternFly component schemas.
 }
 `;
 
+exports[`Builtin tools, HTTP transport should expose expected tools and stable shape: tools 1`] = `
+{
+  "toolNames": [
+    "searchPatternFlyDocs",
+    "useAiHelpersSkill",
+    "usePatternFlyDocs",
+  ],
+}
+`;
+
 exports[`Builtin tools, HTTP transport should concatenate headers and separator with two remote files 1`] = `
 "# Content for https://www.patternfly.org/notARealPath/AboutModal.md
 Source: https://www.patternfly.org/notARealPath/AboutModal.md
@@ -85,23 +95,6 @@ Source: https://www.patternfly.org/notARealPath/ChartLegend.md
 # Test Document
 
 This is a test document for mocking remote HTTP requests."
-`;
-
-exports[`Builtin tools, HTTP transport should expose expected tools and stable shape: tools 1`] = `
-{
-  "toolNames": [
-    "searchPatternFlyDocs",
-    "usePatternFlyDocs",
-  ],
-}
-`;
-
-exports[`Builtin tools, HTTP transport should initialize MCP session over HTTP 1`] = `
-{
-  "baseUrl": "http://127.0.0.1:8000",
-  "name": "@patternfly/patternfly-mcp",
-  "version": "2024-11-05",
-}
 `;
 
 exports[`Builtin tools, HTTP transport should return expected markdown structure for search results: markdown 1`] = `
@@ -140,4 +133,12 @@ exports[`Builtin tools, HTTP transport should return expected markdown structure
 **Important**:
   - Use the "usePatternFlyDocs" tool with the above names and URLs to fetch resource content.
   - Use a search all ("*") to find all available resources."
+`;
+
+exports[`Builtin tools, HTTP transport should initialize MCP session over HTTP 1`] = `
+{
+  "baseUrl": "http://127.0.0.1:8000",
+  "name": "@patternfly/patternfly-mcp",
+  "version": "2024-11-05",
+}
 `;

--- a/tests/e2e/__snapshots__/stdioTransport.test.ts.snap
+++ b/tests/e2e/__snapshots__/stdioTransport.test.ts.snap
@@ -99,6 +99,7 @@ exports[`Builtin tools, STDIO should expose expected tools and stable shape 1`] 
 {
   "toolNames": [
     "searchPatternFlyDocs",
+    "useAiHelpersSkill",
     "usePatternFlyDocs",
   ],
 }
@@ -172,9 +173,15 @@ exports[`Logging should allow setting logging options, stderr 1`] = `
 ",
   "[INFO]: Registered resource: patternfly-schemas-template
 ",
+  "[INFO]: Registered resource: aihelpers-skills-index
+",
+  "[INFO]: Registered resource: aihelpers-skills-template
+",
   "[INFO]: Registered tool: usePatternFlyDocs
 ",
   "[INFO]: Registered tool: searchPatternFlyDocs
+",
+  "[INFO]: Registered tool: useAiHelpersSkill
 ",
   "[INFO]: @patternfly/patternfly-mcp server running on stdio transport
 ",


### PR DESCRIPTION
## Summary

- Adds `useAiHelpersSkill` MCP tool — call with no args to list all skills, pass a name to get full skill content
- Adds `aihelpers://skills/index` resource and `aihelpers://skills/{name}` resource template for MCP client browsing
- Fetches skills dynamically from GitHub at runtime with disk cache fallback — no bundled JSON, no manual sync
- 5-minute in-memory TTL, 10s fetch timeout, graceful degradation if GitHub is unreachable

Companion PR: patternfly/ai-helpers#72 (adds `dist/skills.json` generation + CI auto-update)

Ref: [PF-4034](https://redhat.atlassian.net/browse/PF-4034)

## How it works

An agent in a Claude Code session asks about skills → the MCP server calls `useAiHelpersSkill` → fetches `dist/skills.json` from GitHub → returns skill content to the agent. The agent then follows the skill instructions. No config, no install — just the MCP connection.

## Test plan

End-to-end verification requires patternfly/ai-helpers#72 merged first. Once landed: start a Claude Code session with the PF MCP connected, ask "what ai-helpers skills are available?" → agent lists skills via the tool. Ask it to use a specific skill by name → agent retrieves and follows the skill instructions.