### PR TITLE
feat(tools): pf-4120 resource optimized searchPatternFly

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,13 @@ Welcome to the PatternFly MCP Server documentation. This guide is organized by u
 ### 🚀 Usage
 - **[MCP Tools and Resources](./usage.md)**: Use built-in tools and resources like `searchPatternFlyDocs` and `usePatternFlyDocs`.
 - **[Client Configuration](./usage.md)**: Configure the server for your environment.
+- **[Experimental settings](./experimental.md)**: Opt-in flags that may change; not documented in the stable usage guides.
 - **[Troubleshooting](./usage.md#troubleshooting)**: Steps for common setup problems.
 
 ### 🛠️ Developer reference
 - **[CLI Reference](./development.md#cli-usage)**: Reference of server options.
 - **[API Reference](./development.md#programmatic-usage)**: Using the server as a base library in your own Node.js MCP.
+- **[Experimental settings](./experimental.md)**: CLI and programmatic configuration for experimental flags.
 - **[Examples](./examples/README.md)**: Standalone snippets for HTTP transport, embedding, and custom tools.
 
 ### 🏗️ Architecture & design

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@ Complete guide to using the PatternFly MCP Server for development including CLI 
 **Development:**
 - [CLI usage](#cli-usage)
 - [Programmatic usage](#programmatic-usage)
+- [Experimental settings](./experimental.md)
 - [MCP tool plugins](#mcp-tool-plugins)
 - [Initial troubleshooting](#initial-troubleshooting)
 - [Project maintenance](#project-maintenance)
@@ -36,7 +37,7 @@ Complete guide to using the PatternFly MCP Server for development including CLI 
 - **Programmatic API** - The server can also be used programmatically with options. See [Programmatic usage](#programmatic-usage) for more details.
 - **Tool plugins** - The server can load external tool plugins at startup. See [MCP tool plugins](#mcp-tool-plugins) for more details.
 - **Test Mode** - When `--mode test` is used, the server redirects resource requests to the URL provided by `--mode-test-url`, enabling E2E testing without local filesystem access.
-- **Experimental options** - When an option is registered as experimental, use `--experimental-<lorem-ipsum>` on the CLI; for programmatic options use `experimental<LoremIpsum>`.
+- **Experimental options** - Opt-in flags use `--experimental-<name>` on the CLI and `experimental<Name>` programmatically. See [Experimental settings](./experimental.md) for the current list, examples, and lifecycle notes.
 
 ### Basic use scenarios
 
@@ -122,7 +123,7 @@ The `start()` function accepts an optional `PfMcpOptions` object for programmati
 | `docsPaths`                | `string[]`                               | Whitelist of local documentation directories resolved by `documentation:` slug. When empty (default), the slug is dormant. | `[]`             |
 
 #### Notes
-- **Experimental options** - When an option is registered as experimental use `experimental<LoremIpsum>` for programmatic options; for CLI options use `--experimental-<lorem-ipsum>`.
+- **Experimental options** - Opt-in flags use `experimental<Name>` programmatically and `--experimental-<name>` on the CLI. See [Experimental settings](./experimental.md) for the current list and configuration examples.
 
 #### Example usage
 

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,0 +1,122 @@
+# Experimental settings
+
+Opt-in server options documented here are **not** covered by the same stability guarantees as the rest of the docs. They may change behavior, graduate to stable configuration, or be removed without a major release.
+
+**Stable docs:**
+- [Usage guide](./usage.md) — default tools, resources, and client configuration
+- [Development reference](./development.md) — CLI and programmatic API for supported options
+
+## How experimental options work
+
+- **CLI**: `--experimental-<kebab-name>` (for example, `--experimental-context-management`)
+- **Programmatic**: `experimental<CamelName>` on the object passed to `start()` (for example, `experimentalContextManagement: true`)
+- **Startup**: The server logs a warning when any registered experimental option is enabled
+
+Using an experimental flag without the `experimental` prefix (CLI or programmatic) is ignored.
+
+## Lifecycle
+
+1. **Experimental** — documented only on this page; behavior may change between releases.
+2. **Graduating** — when a flag loses its experimental prefix in code, its documentation moves to [usage](./usage.md) or [development](./development.md) in the same change; remove it from the index below.
+3. **Removed** — when a flag fails to graduate, delete the row and section here; stable docs should not need updates.
+
+## Index
+
+| Internal name       | CLI flag                            | Programmatic option             | Status          |
+|---------------------|-------------------------------------|---------------------------------|-----------------|
+| `contextManagement` | `--experimental-context-management` | `experimentalContextManagement` | experimental    |
+
+---
+
+## contextManagement
+
+Context management (also called **token-saver mode**) switches the server from the default two-step search-and-fetch workflow to a resource-link workflow for MCP clients that read `patternfly://` URIs directly.
+
+> `contextManagement` is part of a broader set of updates intended to optimize the PatternFly MCP server's use of MCP resources and streamline code. Additional refactors may be included under this umbrella under later releases.
+
+| Mode                    | Registered tools                                      | Typical workflow                                                                 |
+|-------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------|
+| **Default** _(off)_     | `searchPatternFlyDocs`, `usePatternFlyDocs`           | Search returns text with URLs and names; fetch content with `usePatternFlyDocs`. |
+| **Context management**  | `searchPatternFly` only                               | Search returns `resource_link` items; read content with `resources/read`.        |
+
+Built-in MCP resources (`patternfly://docs/...`, `patternfly://schemas/...`, indexes, and `patternfly://context`) remain available in both modes.
+
+### Tool: searchPatternFly
+
+Registered only when context management is enabled.
+
+Search PatternFly components, documentation, guidelines, and JSON schemas by keyword. Returns MCP `resource_link` content items (collections, docs, and schemas).
+
+**Parameters:**
+- `query`: `string` (required) — Case-insensitive, full or partial keyword query (e.g., `"button"`, `"react"`, `"*"` for all resources)
+- `version`: `string` (optional) — Filter by PatternFly version (`"current"`, `"latest"`, or `"v6"`)
+
+**Example:**
+```json
+{
+  "query": "button"
+}
+```
+
+### CLI
+
+```bash
+npx -y @patternfly/patternfly-mcp@latest --experimental-context-management
+```
+
+HTTP transport:
+
+```bash
+npx -y @patternfly/patternfly-mcp@latest --http --port 8080 --experimental-context-management
+```
+
+### Programmatic
+
+```typescript
+import { start } from '@patternfly/patternfly-mcp';
+
+const server = await start({
+  experimentalContextManagement: true
+});
+```
+
+### MCP client configuration
+
+Stdio:
+
+```json
+{
+  "mcpServers": {
+    "patternfly-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@patternfly/patternfly-mcp@latest",
+        "--experimental-context-management"
+      ],
+      "description": "PatternFly rules and documentation (experimental context management)"
+    }
+  }
+}
+```
+
+HTTP:
+
+```json
+{
+  "mcpServers": {
+    "patternfly-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@patternfly/patternfly-mcp@latest",
+        "--http",
+        "--port",
+        "8080",
+        "--experimental-context-management"
+      ],
+      "description": "PatternFly rules and documentation (HTTP, experimental context management)"
+    }
+  }
+}
+```

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -22,9 +22,9 @@ Using an experimental flag without the `experimental` prefix (CLI or programmati
 
 ## Index
 
-| Internal name       | CLI flag                            | Programmatic option             | Status          |
-|---------------------|-------------------------------------|---------------------------------|-----------------|
-| `contextManagement` | `--experimental-context-management` | `experimentalContextManagement` | experimental    |
+| Internal name       | CLI flag                            | Programmatic option             | Value type  |
+|---------------------|-------------------------------------|---------------------------------|-------------|
+| `contextManagement` | `--experimental-context-management` | `experimentalContextManagement` | `boolean`   |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,6 +7,7 @@ A comprehensive guide to PatternFly MCP Server tools, resources, and configurati
 - [Built-in resources](#built-in-resources)
 - [MCP client configuration](#mcp-client-configuration)
 - [Custom MCP tool plugins](#custom-mcp-tool-plugins)
+- [Experimental settings](./experimental.md)
 - [Troubleshooting](#troubleshooting)
 
 ## Built-in tools

--- a/src/__tests__/__snapshots__/options.defaults.test.ts.snap
+++ b/src/__tests__/__snapshots__/options.defaults.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`options defaults should return specific properties: defaults 1`] = `
 {
+  "contextManagement": false,
   "contextPath": "/",
   "contextUrl": "file:///",
   "docsPathSlug": "documentation:",

--- a/src/__tests__/__snapshots__/tool.searchPatternFly.test.ts.snap
+++ b/src/__tests__/__snapshots__/tool.searchPatternFly.test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`searchPatternFlyTool should have a consistent return structure: structure 1`] = `
+{
+  "callback": [Function],
+  "name": "searchPatternFly",
+  "schema": true,
+}
+`;
+
+exports[`searchPatternFlyTool, callback should have a specific markdown format: Button 1`] = `
+[
+  {
+    "text": "# Search results for PatternFly version "v6" and "button".
+Found 2 collections with 5 related resources. Use the attached resources to access and read full content.",
+    "type": "text",
+  },
+  {
+    "description": "A resource collection series for Button",
+    "groupId": "123456",
+    "mimeType": "text/markdown",
+    "name": "Button (Collection)",
+    "type": "resource_link",
+    "uri": "patternfly://docs/123456",
+  },
+  {
+    "description": "Design Guidelines",
+    "groupId": "123456",
+    "mimeType": "text/markdown",
+    "name": "Button - Design (v6)",
+    "type": "resource_link",
+    "uri": "patternfly://docs/34567b",
+  },
+  {
+    "description": "Component JSON schema with property definitions for Button.",
+    "groupId": "123456",
+    "mimeType": "text/markdown",
+    "name": "Button - JSON Schema (v6)",
+    "type": "resource_link",
+    "uri": "patternfly://schemas/67b890",
+  },
+  {
+    "description": "A resource collection series for Lorem Button",
+    "groupId": "654321",
+    "mimeType": "text/markdown",
+    "name": "Lorem Button (Collection)",
+    "type": "resource_link",
+    "uri": "patternfly://docs/654321",
+  },
+  {
+    "description": "Design Guidelines",
+    "groupId": "654321",
+    "mimeType": "text/markdown",
+    "name": "Lorem Button - Design (v6)",
+    "type": "resource_link",
+    "uri": "patternfly://docs/e34567",
+  },
+  {
+    "description": "Design Guidelines",
+    "groupId": "654321",
+    "mimeType": "text/markdown",
+    "name": "Lorem Button - Guidelines (v6)",
+    "type": "resource_link",
+    "uri": "patternfly://docs/34567",
+  },
+  {
+    "description": "Component JSON schema with property definitions for Lorem Button.",
+    "groupId": "654321",
+    "mimeType": "text/markdown",
+    "name": "Lorem Button - JSON Schema (v6)",
+    "type": "resource_link",
+    "uri": "patternfly://schemas/678e90",
+  },
+]
+`;
+
+exports[`searchPatternFlyTool, callback should parse parameters, exact match 1`] = `"# Search results for PatternFly version "v6" and "button"."`;
+
+exports[`searchPatternFlyTool, callback should parse parameters, wildcard search 1`] = `"# Search results for PatternFly version "v6" and "all" resources."`;

--- a/src/__tests__/resource.patternFlyContext.test.ts
+++ b/src/__tests__/resource.patternFlyContext.test.ts
@@ -30,12 +30,33 @@ describe('resourceCallback', () => {
     {
       description: 'default',
       expected: 'Troubleshooting'
+    },
+    {
+      description: 'contextManagement enabled',
+      options: {
+        contextManagement: true,
+        experimental: ['contextManagement'],
+        mode: 'test',
+        version: '1.0.0',
+        nodeVersion: 22
+      },
+      expected: [
+        'search, list and access',
+        'list and access available documentation resources',
+        'Active Experimental Features',
+        'contextManagement'
+      ]
     }
-  ])('should return context content, $description', async ({ expected }) => {
-    const result = await resourceCallback(undefined as any);
+  ])('should return context content, $description', async ({ options, expected }) => {
+    const result = await resourceCallback(new URL('patternfly://context'), options as any);
 
     expect(result.contents).toBeDefined();
-    expect(Object.keys(result.contents[0] as any)).toEqual(['uri', 'mimeType', 'text']);
-    expect(result.contents[0]?.text).toContain(expected);
+    const text = result.contents[0]?.text;
+
+    if (Array.isArray(expected)) {
+      expected.forEach(snippet => expect(text).toContain(snippet));
+    } else {
+      expect(text).toContain(expected);
+    }
   });
 });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -90,13 +90,13 @@ describe('runServer', () => {
   it.each([
     {
       description: 'use default tools, stdio',
-      options: { name: 'test-server-1', version: '1.0.0' },
+      options: { name: 'test-server-1', version: '1.0.0', contextManagement: undefined },
       tools: undefined,
       transportMethod: MockStdioServerTransport
     },
     {
       description: 'use default tools, http',
-      options: { name: 'test-server-2', version: '1.0.0', isHttp: true },
+      options: { name: 'test-server-2', version: '1.0.0', isHttp: true, contextManagement: false },
       tools: undefined,
       transportMethod: MockStartHttpTransport
     },

--- a/src/__tests__/tool.searchPatternFly.test.ts
+++ b/src/__tests__/tool.searchPatternFly.test.ts
@@ -1,0 +1,174 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { searchPatternFly } from '../patternFly.search';
+import { getPatternFlyMcpResources } from '../patternFly.getResources';
+import { isPlainObject } from '../server.helpers';
+import { searchPatternFlyTool } from '../tool.searchPatternFly';
+
+// Mock dependencies
+jest.mock('../patternFly.search');
+jest.mock('../patternFly.getResources');
+jest.mock('../server.caching', () => ({
+  memo: jest.fn(fn => fn)
+}));
+
+const mockSearch = searchPatternFly as jest.MockedFunction<typeof searchPatternFly>;
+const mockGetResources = getPatternFlyMcpResources as jest.MockedFunction<typeof getPatternFlyMcpResources>;
+
+describe('searchPatternFlyTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should have a consistent return structure', () => {
+    const tool = searchPatternFlyTool();
+
+    expect({
+      name: tool[0],
+      schema: isPlainObject(tool[1]),
+      callback: tool[2]
+    }).toMatchSnapshot('structure');
+  });
+});
+
+describe('searchPatternFlyTool, callback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetResources.mockResolvedValue({
+      latestVersion: 'v6'
+    } as any);
+
+    mockSearch.mockResolvedValue({
+      isSearchWildCardAll: false,
+      exactMatches: [],
+      remainingMatches: [],
+      searchResults: [],
+      totalPotentialMatches: 0
+    } as any);
+  });
+
+  it.each([
+    {
+      description: 'exact match',
+      query: 'button',
+      searchValue: {
+        totalPotentialMatches: 1
+      }
+    },
+    {
+      description: 'wildcard search',
+      query: '*',
+      searchValue: {
+        isSearchWildCardAll: true,
+        totalPotentialMatches: 50
+      }
+    }
+  ])('should parse parameters, $description', async ({ searchValue, query }) => {
+    mockSearch.mockResolvedValue({
+      isSearchWildCardAll: false,
+      exactMatches: [{
+        name: 'button',
+        entries: [{ displayName: 'Button', version: 'v6', description: 'Docs', path: 'pf/button.md' }],
+        uri: 'patternfly://docs/button?version=v6',
+        uriSchemas: 'patternfly://schemas/button?version=v6'
+      }],
+      remainingMatches: [],
+      searchResults: [{ displayName: 'Button', version: 'v6', description: 'Docs', path: 'pf/button.md' }],
+      ...searchValue
+    } as any);
+
+    const [_name, _schema, callback] = searchPatternFlyTool();
+    const result = await callback({ query });
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toBeDefined();
+    expect(result.content[0].text.split('\n')[0]).toMatchSnapshot();
+  });
+
+  it.each([
+    {
+      description: 'with empty query',
+      error: '"query" must be a string from',
+      query: ''
+    },
+    {
+      description: 'with missing or undefined query',
+      error: '"query" must be a string from',
+      query: undefined
+    },
+    {
+      description: 'with null query',
+      error: '"query" must be a string from',
+      query: null
+    },
+    {
+      description: 'with non-string query',
+      error: '"query" must be a string from',
+      query: 123
+    },
+    {
+      description: 'with a non-existent version',
+      error: '"version" must be one of the following values',
+      query: 'button',
+      version: 'v01'
+    }
+  ])('should handle errors, $description', async ({ error, query, version }) => {
+    const [_name, _schema, callback] = searchPatternFlyTool();
+    const updatedParams = version ? { query, version } : { query };
+
+    await expect(callback(updatedParams)).rejects.toThrow(McpError);
+    await expect(callback(updatedParams)).rejects.toThrow(error);
+  });
+
+  it('should have a specific markdown format', async () => {
+    mockSearch.mockResolvedValue({
+      isSearchWildCardAll: false,
+      exactMatches: [
+        {
+          name: 'LoremButton',
+          groupId: '654321',
+          entries: [
+            {
+              displayName: 'Lorem Button',
+              displayCategory: 'Guidelines',
+              version: 'v6',
+              description: 'Design Guidelines',
+              path: 'https://pf.org/button.md',
+              uriId: 'patternfly://docs/34567',
+              uriSchemasId: 'patternfly://schemas/678e90'
+            }, {
+              displayName: 'Lorem Button',
+              displayCategory: 'Design',
+              version: 'v6',
+              description: 'Design Guidelines',
+              path: 'https://pf.org/button.md',
+              uriId: 'patternfly://docs/e34567',
+              uriSchemasId: 'patternfly://schemas/678e90'
+            }
+          ]
+        },
+        {
+          name: 'Button',
+          groupId: '123456',
+          entries: [{
+            displayName: 'Button',
+            displayCategory: 'Design',
+            version: 'v6',
+            description: 'Design Guidelines',
+            path: 'https://pf.org/button.md',
+            uriId: 'patternfly://docs/34567b',
+            uriSchemasId: 'patternfly://schemas/67b890'
+          }]
+        }
+      ],
+      remainingMatches: [],
+      searchResults: [{ displayName: 'Button', version: 'v6', description: 'Docs', path: 'pf/button.md' }],
+      totalPotentialMatches: 5
+    } as any);
+
+    const [_name, _schema, callback] = searchPatternFlyTool();
+    const result = await callback({ query: 'button' });
+
+    expect(result.content).toMatchSnapshot('Button');
+  });
+});

--- a/src/options.defaults.ts
+++ b/src/options.defaults.ts
@@ -135,8 +135,6 @@ interface LoggingOptions {
  * @interface MinMax
  *
  * @property urlString Minimum and maximum length for URL strings.
- * @property resourceSearches Minimum and maximum number of resource results for searches.
- * @property sha1Hex Minimum and maximum length for SHA-1 hex strings.
  * @property toolSearches Minimum and maximum number of tool results for searches.
  * @property inputStrings Minimum and maximum length for input strings.
  * @property docsToLoad Minimum and maximum number of docs to load.
@@ -325,9 +323,6 @@ const HTTP_OPTIONS: HttpOptions = {
 
 /**
  * Minimum and maximum ranges for various options.
- *
- * @note For resourceSearches you still have to take into account that for every result
- * there could be multiple resources.
  */
 const MIN_MAX: MinMax = {
   urlString: {

--- a/src/options.defaults.ts
+++ b/src/options.defaults.ts
@@ -10,6 +10,9 @@ import { getNodeMajorVersion } from './options.helpers';
  * @interface DefaultOptions
  *
  * @template TLogOptions The logging options type, defaulting to LoggingOptions.
+ * @property contextManagement - Strategy for managing agent context and response sizes, primarily within MCP tools.
+ *    - 'false': Default standard text-heavy responses.
+ *    - 'true': High-efficiency mode for MCP tools, using McpResource links.
  * @property contextPath - Current working directory.
  * @property contextUrl - Current working directory URL.
  * @property docsPaths - List of allowed local documentation directories handled by `docsPathSlug`
@@ -49,6 +52,7 @@ import { getNodeMajorVersion } from './options.helpers';
  * @property xhrFetch - XHR and Fetch options.
  */
 interface DefaultOptions<TLogOptions = LoggingOptions> {
+  contextManagement: boolean;
   contextPath: string;
   contextUrl: string;
   docsPaths: string[];
@@ -131,7 +135,9 @@ interface LoggingOptions {
  * @interface MinMax
  *
  * @property urlString Minimum and maximum length for URL strings.
- * @property toolSearches Minimum and maximum number of tool searches.
+ * @property resourceSearches Minimum and maximum number of resource results for searches.
+ * @property sha1Hex Minimum and maximum length for SHA-1 hex strings.
+ * @property toolSearches Minimum and maximum number of tool results for searches.
  * @property inputStrings Minimum and maximum length for input strings.
  * @property docsToLoad Minimum and maximum number of docs to load.
  */
@@ -319,6 +325,9 @@ const HTTP_OPTIONS: HttpOptions = {
 
 /**
  * Minimum and maximum ranges for various options.
+ *
+ * @note For resourceSearches you still have to take into account that for every result
+ * there could be multiple resources.
  */
 const MIN_MAX: MinMax = {
   urlString: {
@@ -498,6 +507,7 @@ const PLUGIN_ISOLATION: DefaultOptions['pluginIsolation'][] = ['none', 'strict']
  * @type {DefaultOptions} Default options object.
  */
 const DEFAULT_OPTIONS: DefaultOptions = {
+  contextManagement: false,
   contextPath: (process.env.NODE_ENV === 'local' && '/') || resolve(process.cwd()),
   contextUrl: pathToFileURL((process.env.NODE_ENV === 'local' && '/') || resolve(process.cwd())).href,
   docsPaths: [],

--- a/src/options.parser.ts
+++ b/src/options.parser.ts
@@ -224,6 +224,9 @@ const parseCliOptions = (
           }
         }
         break;
+      case '--context-management':
+        result.contextManagement = true;
+        break;
     }
   };
 

--- a/src/options.registry.ts
+++ b/src/options.registry.ts
@@ -1,4 +1,5 @@
 import { type McpToolCreator, type McpResourceCreator } from './mcpSdk';
+import { searchPatternFlyTool } from './tool.searchPatternFly';
 import { usePatternFlyDocsTool } from './tool.patternFlyDocs';
 import { searchPatternFlyDocsTool } from './tool.searchPatternFlyDocs';
 import { patternFlyComponentsIndexResource } from './resource.patternFlyComponentsIndex';
@@ -15,7 +16,8 @@ import { patternFlySchemasTemplateResource } from './resource.patternFlySchemasT
  */
 const builtinTools: McpToolCreator[] = [
   usePatternFlyDocsTool,
-  searchPatternFlyDocsTool
+  searchPatternFlyDocsTool,
+  searchPatternFlyTool
 ];
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -86,7 +86,8 @@ const SET_OPTIONS = {
   docsPaths: defineOption({ cli: false })<DefaultOptions['docsPaths']>(),
   name: defineOption({ cli: false })<string>(),
   toolModules: defineOption({ cli: true })<DefaultOptions['toolModules']>(),
-  version: defineOption({ cli: false })<string>()
+  version: defineOption({ cli: false })<string>(),
+  contextManagement: defineOption({ cli: true, experimental: true })<DefaultOptions['contextManagement']>()
 } as const;
 
 /**

--- a/src/resource.patternFlyContext.ts
+++ b/src/resource.patternFlyContext.ts
@@ -43,7 +43,13 @@ const resourceCallback = async (passedUri: URL, options = getOptions()) => {
     options.repoSupport && `- **Troubleshooting guidance:** ${options.repoSupport}`,
     options.repoBugs && `- **Report bugs:** ${options.repoBugs}`
   );
+  const activeExperimentalFeatures = options.experimental.join(', ') || 'None';
 
+  const availableMcpResources = options.contextManagement
+    ? '- **MCP resources:** Can be used to list and access available documentation resources.'
+    : '- **MCP resources:** Can be used to list, filter, and read available documentation resources.';
+
+  const availableToolFunctions = options.contextManagement ? 'search, list and access' : 'search, fetch and display';
   const context = `PatternFly is an open-source design system for building consistent, accessible user interfaces.
 
 **What is PatternFly?**
@@ -57,13 +63,14 @@ PatternFly provides React components, design guidelines, and development tools f
 
 **PatternFly MCP Server:**
 This MCP server provides tools and resources to access all PatternFly documentation resources ranging from design to development.
-- **MCP tools:** Can be used to search, fetch and display available documentation resources.
-- **MCP resources:** Can be used to list, filter and display available documentation resources.
+- **MCP tools:** Can be used to ${availableToolFunctions} available documentation resources.
+${availableMcpResources}
 
 **Environment:**
 - **MCP Server Mode:** ${options.mode}
 - **MCP Server Version:** ${options.version || 'Unknown'}
 - **Node.js Major Version:** ${options.nodeVersion || 'Unknown'}
+- **Active Experimental Features:** ${activeExperimentalFeatures}
 
 ${(troubleshooting && stringJoin.newline('**Troubleshooting:**', troubleshooting)) || ''}
 `;

--- a/src/tool.patternFlyDocs.ts
+++ b/src/tool.patternFlyDocs.ts
@@ -242,7 +242,10 @@ const usePatternFlyDocsTool = (options = getOptions()): McpTool => {
           .optional().describe(`Filter results by a specific PatternFly version (e.g. ${options.patternflyOptions.availableSearchVersions.map(value => `"${value}"`).join(', ')})`)
       }
     },
-    callback
+    callback,
+    {
+      shouldRegister: opts => opts.contextManagement === false || opts.contextManagement === undefined
+    }
   ];
 };
 

--- a/src/tool.searchPatternFly.ts
+++ b/src/tool.searchPatternFly.ts
@@ -1,0 +1,258 @@
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { type McpTool } from './mcpSdk';
+import { stringJoin } from './server.helpers';
+import { assertInput, assertInputStringLength, assertInputStringNumberEnumLike } from './server.assertions';
+import { findClosest } from './server.search';
+import { getOptions } from './options.context';
+import { searchPatternFly } from './patternFly.search';
+import { getPatternFlyMcpResources } from './patternFly.getResources';
+import { normalizeEnumeratedPatternFlyVersion } from './patternFly.helpers';
+
+/**
+ * searchPatternFly tool function
+ *
+ * Searches for PatternFly resources. Returns MCP Resource Links for
+ * specific documents, JSON schemas, and collections.
+ *
+ * @note This is the initial update to confirm concepts for a larger set of
+ * updates that tie into the concepts of `collections` and `records`. The full
+ * optimizations include API work, skills-as-tools, refactoring getResources
+ * search, and MCP resources. See documentation for experimental settings.
+ *
+ * @param options - Optional configuration options (defaults to OPTIONS)
+ * @returns MCP tool tuple [name, schema, callback]
+ */
+const searchPatternFlyTool = (options = getOptions()): McpTool => {
+  const callback = async (args: any = {}) => {
+    const { query: searchQuery, version } = args;
+    const isVersion = typeof version === 'string' && version.length > 0;
+
+    assertInputStringLength(searchQuery, {
+      ...options.minMax.inputStrings,
+      inputDisplayName: 'query'
+    });
+
+    if (isVersion) {
+      assertInputStringLength(version, {
+        max: options.minMax.inputStrings.max,
+        min: 2,
+        inputDisplayName: 'version'
+      });
+
+      assertInputStringNumberEnumLike(version, options.patternflyOptions.availableSearchVersions, {
+        inputDisplayName: 'version'
+      });
+    }
+
+    const { keywordsIndex, latestVersion } = await getPatternFlyMcpResources.memo();
+    const normalizedVersion = await normalizeEnumeratedPatternFlyVersion(version);
+    const updatedVersion = normalizedVersion || latestVersion;
+
+    const { isSearchWildCardAll, exactMatches, remainingMatches, searchResults, totalPotentialMatches } = await searchPatternFly.memo(
+      searchQuery,
+      { version: updatedVersion },
+      { allowWildCardAll: true, dynamicFilter: true, maxResults: options.minMax.toolSearches.max }
+    );
+
+    assertInput(
+      !isSearchWildCardAll || (isSearchWildCardAll && searchResults.length > 0),
+      stringJoin.newline(
+        `Internal Search Error: The server failed to retrieve PatternFly resources for query "${searchQuery}"`,
+        'Ensure documentation resources are loaded or restart the server.'
+      ),
+      ErrorCode.InternalError
+    );
+
+    if (!isSearchWildCardAll && searchResults.length === 0) {
+      const hint = findClosest.memo(searchQuery, keywordsIndex.toReversed(), { maxDistance: 5 }) || '';
+
+      return {
+        content: [{
+          type: 'text',
+          text: stringJoin.newlineFiltered(
+            `No PatternFly resources found matching "${searchQuery}". ${hint}`
+          )
+        }]
+      };
+    }
+
+    // Default to parsing all remainingMatches
+    let parseResults = remainingMatches;
+
+    if (isSearchWildCardAll || exactMatches.length > 0) {
+      parseResults = exactMatches;
+    } else if (searchResults.some(result => result.distance === 1)) {
+      parseResults = searchResults.filter(result => result.distance === 1);
+    }
+
+    const results = new Map<string, Record<string, unknown>>();
+    const groupSortNames = new Map<string, string>();
+    let numberCollections = 0;
+    let numberRecords = 0;
+
+    parseResults.forEach(result => {
+      if (results.has(result.groupId)) {
+        return;
+      }
+
+      numberCollections += 1;
+
+      const recordNames = new Set<string>();
+
+      result.entries.forEach(record => {
+        if (record.uriId && record.path && !results.has(record.uriId)) {
+          numberRecords += 1;
+          recordNames.add(record.displayName);
+
+          results.set(record.uriId, {
+            type: 'resource_link',
+            uri: record.uriId,
+            name: `${record.displayName} - ${record.displayCategory} (${record.version})`,
+            description: record.description,
+            mimeType: 'text/markdown',
+            groupId: result.groupId
+          });
+        }
+
+        if (record.uriSchemasId && !results.has(record.uriSchemasId)) {
+          numberRecords += 1;
+          recordNames.add(record.displayName);
+
+          results.set(record.uriSchemasId, {
+            type: 'resource_link',
+            uri: record.uriSchemasId,
+            name: `${record.displayName} - JSON Schema (${record.version})`,
+            description: `Component JSON schema with property definitions for ${record.displayName}.`,
+            mimeType: 'text/markdown',
+            groupId: result.groupId
+          });
+        }
+      });
+
+      if (!result.entries) {
+        return;
+      }
+
+      const collectionName = (recordNames.size === 1 ? [...recordNames][0] : result.name) as string;
+      const collectionNames =
+        `${[...recordNames].slice(0, 3).join(', ')}${(recordNames.size > 3 && ', and more') || ''}`.trim() || result.name;
+
+      // Track the name used for sorting this entire group
+      groupSortNames.set(result.groupId, collectionName.toLowerCase());
+
+      results.set(result.groupId, {
+        type: 'resource_link',
+        uri: `patternfly://docs/${result.groupId}`,
+        name: `${collectionName} (Collection)`,
+        description: `A resource collection series for ${collectionNames}`,
+        mimeType: 'text/markdown',
+        groupId: result.groupId
+      });
+    });
+
+    const resultValues = Array.from(results.values()).sort((a, b) => {
+      const gidA = a.groupId as string;
+      const gidB = b.groupId as string;
+
+      // 1. Sort by Group (using the Collection's name)
+      if (gidA !== gidB) {
+        const nameA = groupSortNames.get(gidA) || '';
+        const nameB = groupSortNames.get(gidB) || '';
+
+        return nameA.localeCompare(nameB);
+      }
+
+      // 2. Define Priority within the same group
+      const getPriority = (item: string) => {
+        const name = item.toLowerCase();
+
+        if (name.endsWith('(collection)')) {
+          return 0;
+        }
+        if (name.includes('json schema')) {
+          return 2;
+        }
+
+        return 1;
+      };
+
+      const priorityA = getPriority(a.name as string);
+      const priorityB = getPriority(b.name as string);
+
+      if (priorityA !== priorityB) {
+        return priorityA - priorityB;
+      }
+
+      // 3. Fallback to name comparison within the same priority level
+      return (a.name as string).localeCompare(b.name as string);
+    });
+
+    const summaryTitlePatternFly = updatedVersion
+      ? `Search results for PatternFly version "${updatedVersion}" and`
+      : `Search results for`;
+
+    const totalCollectionsRecords = numberCollections + numberRecords;
+    const basePluralResource = totalCollectionsRecords === 1 ? 'resource' : 'resources';
+
+    const baseSummaryTitle = stringJoin.filtered(
+      `Found ${totalCollectionsRecords} related ${basePluralResource}.`,
+      totalCollectionsRecords > 0 ? `Use the attached ${basePluralResource} to access and read full content.` : ''
+    );
+
+    let summaryTitle = stringJoin.newline(
+      `# ${summaryTitlePatternFly} "${searchQuery}".`,
+      baseSummaryTitle
+    );
+
+    if (isSearchWildCardAll) {
+      summaryTitle = stringJoin.newline(
+        `# ${summaryTitlePatternFly} "all" resources.`,
+        `Only showing ${totalCollectionsRecords} ${basePluralResource} out of ${totalPotentialMatches} potential matches. Use a more specific query.`
+      );
+    } else if (exactMatches.length > 0) {
+      summaryTitle = stringJoin.newlineFiltered(
+        `# ${summaryTitlePatternFly} "${searchQuery}".`,
+        stringJoin.filtered(
+          numberCollections > 0 && `Found ${numberCollections} ${numberCollections === 1 ? 'collection' : 'collections'} with ${numberRecords} related resources.`,
+          numberCollections === 0 && `Found ${totalCollectionsRecords} exact ${basePluralResource}.`,
+          `Use the attached ${basePluralResource} to access and read full content.`
+        )
+      );
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summaryTitle
+        },
+        ...resultValues
+      ]
+    };
+  };
+
+  return [
+    'searchPatternFly',
+    {
+      description: `Search PatternFly components, documentation, guidelines, and resource links by keywords or '*' for all.`,
+      inputSchema: {
+        query: z.string()
+          .min(options.minMax.inputStrings.min)
+          .max(options.minMax.inputStrings.max)
+          .describe('Case-insensitive, full or partial keyword query (e.g., "button", "react", "*")'),
+        version: z.enum(options.patternflyOptions.availableSearchVersions)
+          .optional()
+          .describe(`Filter results by a specific PatternFly version (e.g. ${options.patternflyOptions.availableSearchVersions.map(value => `"${value}"`).join(', ')})`)
+      }
+    },
+    callback,
+    {
+      shouldRegister: opts => opts.contextManagement === true
+    }
+  ];
+};
+
+searchPatternFlyTool.toolName = 'searchPatternFly';
+
+export { searchPatternFlyTool };

--- a/src/tool.searchPatternFly.ts
+++ b/src/tool.searchPatternFly.ts
@@ -65,13 +65,14 @@ const searchPatternFlyTool = (options = getOptions()): McpTool => {
     );
 
     if (!isSearchWildCardAll && searchResults.length === 0) {
-      const hint = findClosest.memo(searchQuery, keywordsIndex.toReversed(), { maxDistance: 5 }) || '';
+      const hint = findClosest.memo(searchQuery, keywordsIndex.toReversed(), { maxDistance: 5 });
 
       return {
         content: [{
           type: 'text',
-          text: stringJoin.newlineFiltered(
-            `No PatternFly resources found matching "${searchQuery}". ${hint}`
+          text: stringJoin.filtered(
+            `No PatternFly resources found matching "${searchQuery}".`,
+            hint && `Try a search for "${hint}".`
           )
         }]
       };

--- a/src/tool.searchPatternFly.ts
+++ b/src/tool.searchPatternFly.ts
@@ -131,7 +131,7 @@ const searchPatternFlyTool = (options = getOptions()): McpTool => {
         }
       });
 
-      if (!result.entries) {
+      if (!result.entries.length) {
         return;
       }
 

--- a/src/tool.searchPatternFlyDocs.ts
+++ b/src/tool.searchPatternFlyDocs.ts
@@ -170,7 +170,10 @@ const searchPatternFlyDocsTool = (options = getOptions()): McpTool => {
           .describe(`Filter results by a specific PatternFly version (e.g. ${options.patternflyOptions.availableSearchVersions.map(value => `"${value}"`).join(', ')})`)
       }
     },
-    callback
+    callback,
+    {
+      shouldRegister: opts => opts.contextManagement === false || opts.contextManagement === undefined
+    }
   ];
 };
 

--- a/tests/e2e/__snapshots__/stdioTransport.test.ts.snap
+++ b/tests/e2e/__snapshots__/stdioTransport.test.ts.snap
@@ -181,6 +181,8 @@ exports[`Logging should allow setting logging options, stderr 1`] = `
 ]
 `;
 
+exports[`Logging should allow setting logging options, with experimental flag set 1`] = `[]`;
+
 exports[`Logging should allow setting logging options, with log level filtering 1`] = `[]`;
 
 exports[`Logging should allow setting logging options, with mcp protocol 1`] = `

--- a/tests/e2e/httpTransport.test.ts
+++ b/tests/e2e/httpTransport.test.ts
@@ -523,3 +523,52 @@ describe('Inline tools, HTTP transport', () => {
     await CLIENT.close();
   });
 });
+
+describe('token-saver mode, HTTP transport', () => {
+  let CLIENT: HttpTransportClient | undefined;
+
+  beforeAll(async () => {
+    CLIENT = await startServer({
+      isHttp: true,
+      experimentalContextManagement: true
+    });
+  });
+
+  afterAll(async () => {
+    if (CLIENT) {
+      await CLIENT.close();
+    }
+  });
+
+  it('should only expose searchPatternFly tool', async () => {
+    const response = await CLIENT?.send({
+      method: 'tools/list',
+      params: {}
+    });
+    const tools = response?.result?.tools || [];
+    const toolNames = tools.map((tool: any) => tool.name);
+
+    expect(toolNames).toEqual(['searchPatternFly']);
+  });
+
+  it('should return McpResource links from searchPatternFly', async () => {
+    const response = await CLIENT?.send({
+      method: 'tools/call',
+      params: {
+        name: 'searchPatternFly',
+        arguments: {
+          query: 'Button'
+        }
+      }
+    });
+
+    const [summary, ...resources] = response?.result?.content || [];
+
+    expect(summary.type).toBe('text');
+
+    resources.forEach((item: any) => {
+      expect(item.type).toBe('resource_link');
+      expect(item.uri).toMatch(/^patternfly:\/\/(docs|schemas)\//);
+    });
+  });
+});

--- a/tests/e2e/stdioTransport.test.ts
+++ b/tests/e2e/stdioTransport.test.ts
@@ -476,6 +476,10 @@ describe('Logging', () => {
     {
       description: 'with mcp protocol',
       args: ['--log-protocol']
+    },
+    {
+      description: 'with experimental flag set',
+      args: ['--experimental-context-management']
     }
   ])('should allow setting logging options, $description', async ({ args }) => {
     const serverArgs = [...args];
@@ -554,5 +558,66 @@ describe('Tools', () => {
 
     expect(resp.result).toMatchSnapshot();
     expect(resp.result.isError).toBeUndefined();
+  });
+});
+
+describe('token-saver mode', () => {
+  let CLIENT: StdioTransportClient;
+
+  beforeAll(async () => {
+    CLIENT = await startServer({
+      args: ['--experimental-context-management']
+    });
+  });
+
+  afterAll(async () => {
+    if (CLIENT) {
+      await CLIENT.close();
+    }
+  });
+
+  it('should only expose searchPatternFly tool', async () => {
+    const response = await CLIENT.send({
+      method: 'tools/list',
+      params: {}
+    });
+    const tools = response?.result?.tools || [];
+    const toolNames = tools.map((tool: any) => tool.name);
+
+    expect(toolNames).toEqual(['searchPatternFly']);
+  });
+
+  it('should return McpResource links from searchPatternFly', async () => {
+    const response = await CLIENT.send({
+      method: 'tools/call',
+      params: {
+        name: 'searchPatternFly',
+        arguments: {
+          query: 'Button'
+        }
+      }
+    });
+
+    const [summary, ...resources] = response?.result?.content || [];
+
+    expect(summary.type).toBe('text');
+
+    resources.forEach((item: any) => {
+      expect(item.type).toBe('resource_link');
+      expect(item.uri).toMatch(/^patternfly:\/\/(docs|schemas)\//);
+    });
+
+    const link = resources.find((item: any) => item.uri.startsWith('patternfly://docs/') && !item.name.includes('Collection'));
+
+    expect(link).toBeDefined();
+
+    // Verify we can read the resource using the discovered ID
+    const readResponse = await CLIENT.send({
+      method: 'resources/read',
+      params: { uri: link.uri }
+    });
+
+    expect(readResponse.result.contents[0].text).toBeDefined();
+    expect(readResponse.result.contents[0].uri).toBe(link.uri);
   });
 });

--- a/tests/e2e/utils/httpTransportClient.ts
+++ b/tests/e2e/utils/httpTransportClient.ts
@@ -25,6 +25,7 @@ export type StartHttpServerOptions = {
   logging?: Partial<PfMcpOptions['logging']> & { level?: LoggingLevel };
   toolModules?: PfMcpOptions['toolModules'];
   modeOptions?: PfMcpOptions['modeOptions'];
+  experimentalContextManagement?: PfMcpOptions['experimentalContextManagement'];
 };
 
 export type StartHttpServerSettings = PfMcpSettings;


### PR DESCRIPTION
<!--
PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues for confirmation that the work isn't already in progress.
- Review our [PR contributing guidelines](https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md#pull-requests).
-->
## What is it?
<!-- Summary of changes/additions/commits -->
- feat(tools): pf-4120 resource optimized searchPatternFly

### Notes
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->
- experimental `bool` flag activated - `--experimental-context-management` or `experimentalContextManagement` 
   - turns 2 tools into one. the current `search` and `use` are refined into just `searchPatternFly`
      - leaves the remaining tool available for a refactor towards aspects of #18 
   - the flag may be removed from under `experimental` under subsequent releases
   - intended to target MCP clients that read resources. the new tool response removes most of the "human level" markdown and favors resource responses, leaving the model to algorithm the choice
- introduces the concepts of `collections` and `records`. the intention is to migrate towards a reduced set of MCP resources under `patternfly://collections/{id}{?detail}` and `patternfly://records/{id}{?detail}`. [that refactor work is located here](https://github.com/cdcabrera/patternfly-mcp/tree/20260608-bckup-pf-4120-searchpf) 


<!-- ## How to test-->
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
<!--
### Check the work
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. `npx -y @modelcontextprotocol/inspector node dist/cli.js`
1. next...
-->
<!--
### Unit test check
1. Update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### E2E test check
1. Update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->
<!--
### Check the build
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
closes #184 
pf-4120

related to #148 