### PR TITLE
fix: pf-4120 central mcp sdk typings

### DIFF
--- a/src/mcpSdk.ts
+++ b/src/mcpSdk.ts
@@ -76,6 +76,24 @@ interface McpResourceMetadataMetaConfig {
 }
 
 /**
+ * Complete callback for MCP resource templates.
+ *
+ * @note Use {@link McpResourceMetadataCompleteMemo} for memoized use.
+ */
+type McpResourceMetadataComplete = CompleteResourceTemplateCallback;
+
+/**
+ * Complete callback with memoization for MCP resource templates.
+ *
+ * The structure can provide:
+ * - A `CompleteResourceTemplateCallback` directly.
+ * - A function property requiring a `memo` property containing a memoized version of the callback.
+ *
+ * @note Use {@link McpResourceMetadataComplete} for non-memoized use.
+ */
+type McpResourceMetadataCompleteMemo = { memo: CompleteResourceTemplateCallback } & CompleteResourceTemplateCallback;
+
+/**
  * A resource metadata configuration for the MCP server.
  *
  * @property registerAllSearchCombinations - Whether to register all search combinations for the resource.
@@ -87,9 +105,26 @@ interface McpResourceMetadata {
   registerAllSearchCombinations?: boolean | undefined;
   metaConfig?: McpResourceMetadataMetaConfig;
   complete?: {
-    [key: string]: CompleteResourceTemplateCallback;
+    [callback: string]: McpResourceMetadataCompleteMemo | McpResourceMetadataComplete;
   } | undefined;
   [key: string]: unknown;
+}
+
+/**
+ * List resources result type.
+ *
+ * @note This is temporary until MCP SDK exports ListResourcesResult.
+ *
+ * @property uri - The fully qualified URI of the resource.
+ * @property name - A human-readable name for the resource.
+ * @property [mimeType] - The MIME type of the content.
+ * @property [description] - A brief hint for the model.
+ */
+interface McpResourceListResult {
+  uri: string;
+  name: string;
+  mimeType?: string;
+  description?: string;
 }
 
 /**
@@ -231,8 +266,11 @@ export {
   registerResource,
   type McpTool,
   type McpToolCreator,
+  type McpResourceListResult,
   type McpResourceMetadataMetaConfig,
   type McpResourceMetadata,
+  type McpResourceMetadataComplete,
+  type McpResourceMetadataCompleteMemo,
   type McpResource,
   type McpResourceCreator
 };

--- a/src/resource.patternFlyComponentsIndex.ts
+++ b/src/resource.patternFlyComponentsIndex.ts
@@ -1,8 +1,10 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  ResourceTemplate,
-  type CompleteResourceTemplateCallback
-} from '@modelcontextprotocol/sdk/server/mcp.js';
-import { type McpResource } from './mcpSdk';
+  type McpResource,
+  type McpResourceListResult,
+  type McpResourceMetadataComplete,
+  type McpResourceMetadataCompleteMemo
+} from './mcpSdk';
 import { memo } from './server.caching';
 import { buildSearchString, stringJoin } from './server.helpers';
 import { assertInput, assertInputStringLength } from './server.assertions';
@@ -10,10 +12,6 @@ import { getOptions, runWithOptions } from './options.context';
 import { normalizeEnumeratedPatternFlyVersion } from './patternFly.helpers';
 import { getPatternFlyMcpResources } from './patternFly.getResources';
 import { filterPatternFly } from './patternFly.search';
-import {
-  type PatternFlyListResourceResult,
-  type ExtendedCompleteResourceTemplateCallback
-} from './resource.patternFlyDocsIndex';
 import { paramCompletion } from './resource.helpers';
 
 /**
@@ -46,11 +44,11 @@ const CONFIG = {
  * @note We use "byVersionComponentNames" instead of "byVersion" because it's specific to components.
  * Docs resources don't necessarily contain all components.
  *
- * @returns {Promise<PatternFlyListResourceResult>} The list of available resources.
+ * @returns The list of available resources.
  */
 const listResources = async () => {
   const { availableVersions, byVersionComponentNames } = await getPatternFlyMcpResources.memo();
-  const resources: PatternFlyListResourceResult[] = [];
+  const resources: McpResourceListResult[] = [];
 
   Array.from(byVersionComponentNames)
     .filter(([version]) => availableVersions.includes(version))
@@ -89,7 +87,7 @@ listResources.memo = memo(listResources);
  * @param context - The completion context containing arguments for the URI template.
  * @returns The list of available categories, or an empty list.
  */
-const uriCategoryComplete: ExtendedCompleteResourceTemplateCallback = async (category: string, context) => {
+const uriCategoryComplete: McpResourceMetadataCompleteMemo = async (category: string, context) => {
   const { version, name } = context?.arguments || {};
   const section = 'components';
   const { categories } = await paramCompletion({ category, name, section, version });
@@ -109,7 +107,7 @@ uriCategoryComplete.memo = memo(uriCategoryComplete);
  * @param context - The completion context containing arguments for the URI template.
  * @returns The list of available versions, or an empty list.
  */
-const uriVersionComplete: ExtendedCompleteResourceTemplateCallback = async (version: string, context) => {
+const uriVersionComplete: McpResourceMetadataCompleteMemo = async (version: string, context) => {
   const { category, name } = context?.arguments || {};
   const section = 'components';
   const { versions } = await paramCompletion({ category, name, section, version });
@@ -193,7 +191,7 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
 const patternFlyComponentsIndexResource = (options = getOptions()): McpResource => {
   const list = async () => runWithOptions(options, async () => listResources.memo());
 
-  const complete: { [callback: string]: CompleteResourceTemplateCallback } = {
+  const complete: { [callback: string]: McpResourceMetadataComplete } = {
     category: async (...args) => runWithOptions(options, async () => uriCategoryComplete.memo(...args)),
     version: async (...args) => runWithOptions(options, async () => uriVersionComplete.memo(...args))
   };

--- a/src/resource.patternFlyDocsIndex.ts
+++ b/src/resource.patternFlyDocsIndex.ts
@@ -1,8 +1,10 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  ResourceTemplate,
-  type CompleteResourceTemplateCallback
-} from '@modelcontextprotocol/sdk/server/mcp.js';
-import { type McpResource } from './mcpSdk';
+  type McpResource,
+  type McpResourceListResult,
+  type McpResourceMetadataComplete,
+  type McpResourceMetadataCompleteMemo
+} from './mcpSdk';
 import { memo } from './server.caching';
 import { buildSearchString, stringJoin } from './server.helpers';
 import { assertInput, assertInputStringLength } from './server.assertions';
@@ -11,31 +13,6 @@ import { getPatternFlyMcpResources } from './patternFly.getResources';
 import { normalizeEnumeratedPatternFlyVersion } from './patternFly.helpers';
 import { filterPatternFly } from './patternFly.search';
 import { paramCompletion } from './resource.helpers';
-
-/**
- * Extended callback type that combines the `CompleteResourceTemplateCallback` type
- * and an additional `memo` property.
- *
- * @extends CompleteResourceTemplateCallback
- */
-type ExtendedCompleteResourceTemplateCallback = { memo: CompleteResourceTemplateCallback } & CompleteResourceTemplateCallback;
-
-/**
- * List resources result type.
- *
- * @note This is temporary until MCP SDK exports ListResourcesResult.
- *
- * @property uri - The fully qualified URI of the resource.
- * @property name - A human-readable name for the resource.
- * @property [mimeType] - The MIME type of the content.
- * @property [description] - A brief hint for the model.
- */
-type PatternFlyListResourceResult = {
-  uri: string;
-  name: string;
-  mimeType?: string;
-  description?: string;
-};
 
 /**
  * Name of the resource.
@@ -66,11 +43,11 @@ const CONFIG = {
  *
  * @note It's important to keep lists focused and concise, avoid listing all resources.
  *
- * @returns {Promise<PatternFlyListResourceResult>} The list of available resources.
+ * @returns The list of available resources.
  */
 const listResources = async () => {
   const { availableVersions, byVersion } = await getPatternFlyMcpResources.memo();
-  const resources: PatternFlyListResourceResult[] = [];
+  const resources: McpResourceListResult[] = [];
 
   Object.entries(byVersion)
     .filter(([version]) => availableVersions.includes(version))
@@ -112,7 +89,7 @@ listResources.memo = memo(listResources);
  * @param context - The completion context.
  * @returns The list of available names.
  */
-const uriNameComplete: ExtendedCompleteResourceTemplateCallback = async (name: string, context) => {
+const uriNameComplete: McpResourceMetadataCompleteMemo = async (name: string, context) => {
   const { version, category, section } = context?.arguments || {};
   const { names } = await paramCompletion({ category, name, section, version });
 
@@ -131,7 +108,7 @@ uriNameComplete.memo = memo(uriNameComplete);
  * @param context - The completion context containing arguments for the URI template.
  * @returns The list of available categories, or an empty list.
  */
-const uriCategoryComplete: ExtendedCompleteResourceTemplateCallback = async (category: string, context) => {
+const uriCategoryComplete: McpResourceMetadataCompleteMemo = async (category: string, context) => {
   const { version, section, name } = context?.arguments || {};
   const { categories } = await paramCompletion({ category, name, section, version });
 
@@ -150,7 +127,7 @@ uriCategoryComplete.memo = memo(uriCategoryComplete);
  * @param context - The completion context containing arguments for the URI template.
  * @returns The list of available sections, or an empty list.
  */
-const uriSectionComplete: ExtendedCompleteResourceTemplateCallback = async (section: string, context) => {
+const uriSectionComplete: McpResourceMetadataCompleteMemo = async (section: string, context) => {
   const { version, category, name } = context?.arguments || {};
   const { sections } = await paramCompletion({ category, name, section, version });
 
@@ -169,7 +146,7 @@ uriSectionComplete.memo = memo(uriSectionComplete);
  * @param context - The completion context containing arguments for the URI template.
  * @returns The list of available versions, or an empty list.
  */
-const uriVersionComplete: ExtendedCompleteResourceTemplateCallback = async (version: string, context) => {
+const uriVersionComplete: McpResourceMetadataCompleteMemo = async (version: string, context) => {
   const { section, category, name } = context?.arguments || {};
   const { versions } = await paramCompletion({ category, name, section, version });
 
@@ -295,7 +272,7 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
 const patternFlyDocsIndexResource = (options = getOptions()): McpResource => {
   const list = async () => runWithOptions(options, async () => listResources.memo());
 
-  const complete: { [callback: string]: CompleteResourceTemplateCallback } = {
+  const complete: { [callback: string]: McpResourceMetadataComplete } = {
     category: async (...args) => runWithOptions(options, async () => uriCategoryComplete.memo(...args)),
     section: async (...args) => runWithOptions(options, async () => uriSectionComplete.memo(...args)),
     version: async (...args) => runWithOptions(options, async () => uriVersionComplete.memo(...args))
@@ -335,7 +312,5 @@ export {
   NAME,
   URI_TEMPLATE,
   URI_DESCRIPTION,
-  CONFIG,
-  type ExtendedCompleteResourceTemplateCallback,
-  type PatternFlyListResourceResult
+  CONFIG
 };

--- a/src/resource.patternFlyDocsTemplate.ts
+++ b/src/resource.patternFlyDocsTemplate.ts
@@ -1,9 +1,6 @@
-import {
-  ResourceTemplate,
-  type CompleteResourceTemplateCallback
-} from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { type McpResource } from './mcpSdk';
+import { type McpResource, type McpResourceMetadataComplete } from './mcpSdk';
 import { processDocsFunction } from './server.getResources';
 import { stringJoin } from './server.helpers';
 import { assertInput, assertInputStringLength } from './server.assertions';
@@ -184,7 +181,7 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
 const patternFlyDocsTemplateResource = (options = getOptions()): McpResource => {
   const list = undefined;
 
-  const complete: { [callback: string]: CompleteResourceTemplateCallback } = {
+  const complete: { [callback: string]: McpResourceMetadataComplete } = {
     category: async (...args) => runWithOptions(options, async () => uriCategoryComplete.memo(...args)),
     name: async (...args) => runWithOptions(options, async () => uriNameComplete.memo(...args)),
     section: async (...args) => runWithOptions(options, async () => uriSectionComplete.memo(...args)),

--- a/src/resource.patternFlySchemasIndex.ts
+++ b/src/resource.patternFlySchemasIndex.ts
@@ -1,14 +1,14 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  ResourceTemplate,
-  type CompleteResourceTemplateCallback
-} from '@modelcontextprotocol/sdk/server/mcp.js';
-import { type McpResource } from './mcpSdk';
+  type McpResource,
+  type McpResourceListResult,
+  type McpResourceMetadataComplete
+} from './mcpSdk';
 import { memo } from './server.caching';
 import { stringJoin } from './server.helpers';
 import { assertInput, assertInputStringLength } from './server.assertions';
 import { getOptions, runWithOptions } from './options.context';
 import { getPatternFlyMcpResources } from './patternFly.getResources';
-import { type PatternFlyListResourceResult } from './resource.patternFlyDocsIndex';
 import { normalizeEnumeratedPatternFlyVersion } from './patternFly.helpers';
 import { filterPatternFly } from './patternFly.search';
 import { uriCategoryComplete, uriVersionComplete } from './resource.patternFlyComponentsIndex';
@@ -40,11 +40,11 @@ const CONFIG = {
 /**
  * List resources callback for the URI template.
  *
- * @returns {Promise<PatternFlyListResourceResult>} The list of available resources.
+ * @returns The list of available resources.
  */
 const listResources = async () => {
   const { availableSchemasVersions, byVersionComponentNames } = await getPatternFlyMcpResources.memo();
-  const resources: PatternFlyListResourceResult[] = [];
+  const resources: McpResourceListResult[] = [];
 
   Array.from(byVersionComponentNames)
     .filter(([version]) => availableSchemasVersions.includes(version))
@@ -160,7 +160,7 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
 const patternFlySchemasIndexResource = (options = getOptions()): McpResource => {
   const list = async () => runWithOptions(options, async () => listResources.memo());
 
-  const complete: { [callback: string]: CompleteResourceTemplateCallback } = {
+  const complete: { [callback: string]: McpResourceMetadataComplete } = {
     category: async (...args) => runWithOptions(options, async () => uriCategoryComplete.memo(...args)),
     version: async (...args) => runWithOptions(options, async () => uriVersionComplete.memo(...args))
   };

--- a/src/resource.patternFlySchemasTemplate.ts
+++ b/src/resource.patternFlySchemasTemplate.ts
@@ -1,8 +1,9 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  ResourceTemplate,
-  type CompleteResourceTemplateCallback
-} from '@modelcontextprotocol/sdk/server/mcp.js';
-import { type McpResource } from './mcpSdk';
+  type McpResource,
+  type McpResourceMetadataComplete,
+  type McpResourceMetadataCompleteMemo
+} from './mcpSdk';
 import { memo } from './server.caching';
 import { assertInput, assertInputStringLength } from './server.assertions';
 import { getOptions, runWithOptions } from './options.context';
@@ -13,7 +14,6 @@ import {
 } from './patternFly.getResources';
 import { normalizeEnumeratedPatternFlyVersion } from './patternFly.helpers';
 import { uriCategoryComplete, uriVersionComplete } from './resource.patternFlyComponentsIndex';
-import { type ExtendedCompleteResourceTemplateCallback } from './resource.patternFlyDocsIndex';
 import { paramCompletion } from './resource.helpers';
 
 /**
@@ -47,7 +47,7 @@ const CONFIG = {
  * @param context - The completion context.
  * @returns The list of available names.
  */
-const uriNameComplete: ExtendedCompleteResourceTemplateCallback = async (name: string, context) => {
+const uriNameComplete: McpResourceMetadataCompleteMemo = async (name: string, context) => {
   const { version, category } = context?.arguments || {};
   const section = 'components';
   const { names } = await paramCompletion({ category, name, section, version });
@@ -149,7 +149,7 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
 const patternFlySchemasTemplateResource = (options = getOptions()): McpResource => {
   const list = undefined;
 
-  const complete: { [callback: string]: CompleteResourceTemplateCallback } = {
+  const complete: { [callback: string]: McpResourceMetadataComplete } = {
     category: async (...args) => runWithOptions(options, async () => uriCategoryComplete.memo(...args)),
     name: async (...args) => runWithOptions(options, async () => uriNameComplete.memo(...args)),
     version: async (...args) => runWithOptions(options, async () => uriVersionComplete.memo(...args))


### PR DESCRIPTION
<!--
PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues for confirmation that the work isn't already in progress.
- Review our [PR contributing guidelines](https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md#pull-requests).
-->
## What is it?
<!-- Summary of changes/additions/commits -->
- fix: pf-4120 central mcp sdk typings

### Notes
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->
- clean up centralized type enhancements for mcp sdk use

<!-- ## How to test-->
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
<!--
### Check the work
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. `npx -y @modelcontextprotocol/inspector node dist/cli.js`
1. next...
-->
<!--
### Unit test check
1. Update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### E2E test check
1. Update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->
<!--
### Check the build
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing
related #211 #184 #215 and pf-4120