### PR TITLE
refactor(options): pf-3874 log to channel basename

### DIFF
--- a/src/__tests__/__snapshots__/logger.test.ts.snap
+++ b/src/__tests__/__snapshots__/logger.test.ts.snap
@@ -20,13 +20,13 @@ exports[`createLogger should attempt to subscribe and unsubscribe from a channel
 {
   "subscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
   "unsubscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
@@ -77,7 +77,7 @@ exports[`publish should attempt to create a log entry, args 1`] = `
 {
   "channel": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
     ],
   ],
   "publish": [
@@ -127,7 +127,7 @@ exports[`publish should attempt to create a log entry, default 1`] = `
 {
   "channel": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
     ],
   ],
   "publish": [
@@ -146,7 +146,7 @@ exports[`publish should attempt to create a log entry, level 1`] = `
 {
   "channel": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
     ],
   ],
   "publish": [
@@ -165,7 +165,7 @@ exports[`publish should attempt to create a log entry, msg 1`] = `
 {
   "channel": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
     ],
   ],
   "publish": [
@@ -194,13 +194,13 @@ exports[`registerStderrSubscriber should attempt to subscribe and unsubscribe fr
 {
   "subscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
   "unsubscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
@@ -211,13 +211,13 @@ exports[`subscribeToChannel should attempt to subscribe and unsubscribe from a c
 {
   "subscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
   "unsubscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],

--- a/src/__tests__/__snapshots__/server.logger.test.ts.snap
+++ b/src/__tests__/__snapshots__/server.logger.test.ts.snap
@@ -11,13 +11,13 @@ exports[`createServerLogger should attempt to subscribe and unsubscribe from a c
 {
   "subscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
   "unsubscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
@@ -28,21 +28,21 @@ exports[`createServerLogger should attempt to subscribe and unsubscribe from a c
 {
   "subscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
   "unsubscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
@@ -74,13 +74,13 @@ exports[`registerMcpSubscriber should attempt to subscribe and unsubscribe from 
 {
   "subscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],
   "unsubscribe": [
     [
-      "pf-mcp:log:1234d567-1ce9-123d-1413-a1234e56c789",
+      "pf-mcp:programmatic:log:1234d567-1ce9-123d-1413-a1234e56c789",
       [Function],
     ],
   ],

--- a/src/options.context.ts
+++ b/src/options.context.ts
@@ -9,7 +9,7 @@ import {
 } from './options';
 import {
   DEFAULT_OPTIONS,
-  LOG_BASENAME,
+  CHANNEL_BASENAME,
   MODE_LEVELS,
   PLUGIN_ISOLATION,
   type LoggingSession,
@@ -40,8 +40,9 @@ const getPublicSessionHash = (sessionId: string): string =>
  * @returns {AppSession} Immutable session with a session ID and channel name.
  */
 const initializeSession = (): AppSession => {
+  const { mode } = getOptions();
   const sessionId = (process.env.NODE_ENV === 'local' && '1234d567-1ce9-123d-1413-a1234e56c789') || randomUUID();
-  const channelName = `${LOG_BASENAME}:${sessionId}`;
+  const channelName = `${CHANNEL_BASENAME}:${mode}:log:${sessionId}`;
   const publicSessionId = getPublicSessionHash(sessionId);
 
   return freezeObject({ sessionId, channelName, publicSessionId });
@@ -185,12 +186,12 @@ const getLoggerOptions = (session = getSessionOptions()): LoggingSession => {
  * @returns {StatsSession} Stats options from context.
  */
 const getStatsOptions = (options = getSessionOptions()): StatsSession => {
-  const base = getOptions().stats;
+  const { stats: base, mode } = getOptions();
   const publicSessionId = options.publicSessionId;
-  const health = `pf-mcp:stats:health:${publicSessionId}`;
-  const session = `pf-mcp:stats:session:${publicSessionId}`;
-  const transport = `pf-mcp:stats:transport:${publicSessionId}`;
-  const traffic = `pf-mcp:stats:traffic:${publicSessionId}`;
+  const health = `${CHANNEL_BASENAME}:${mode}:stats:health:${publicSessionId}`;
+  const session = `${CHANNEL_BASENAME}:${mode}:stats:session:${publicSessionId}`;
+  const transport = `${CHANNEL_BASENAME}:${mode}:stats:transport:${publicSessionId}`;
+  const traffic = `${CHANNEL_BASENAME}:${mode}:stats:traffic:${publicSessionId}`;
   const channels = { health, transport, traffic, session };
 
   return { ...base, publicSessionId, channels };

--- a/src/options.context.ts
+++ b/src/options.context.ts
@@ -188,11 +188,14 @@ const getLoggerOptions = (session = getSessionOptions()): LoggingSession => {
 const getStatsOptions = (options = getSessionOptions()): StatsSession => {
   const { stats: base, mode } = getOptions();
   const publicSessionId = options.publicSessionId;
-  const health = `${CHANNEL_BASENAME}:${mode}:stats:health:${publicSessionId}`;
-  const session = `${CHANNEL_BASENAME}:${mode}:stats:session:${publicSessionId}`;
-  const transport = `${CHANNEL_BASENAME}:${mode}:stats:transport:${publicSessionId}`;
-  const traffic = `${CHANNEL_BASENAME}:${mode}:stats:traffic:${publicSessionId}`;
-  const channels = { health, transport, traffic, session };
+  const channel = (type: string) => `${CHANNEL_BASENAME}:${mode}:stats:${type}:${publicSessionId}`;
+
+  const channels = {
+    health: channel('health'),
+    transport: channel('transport'),
+    traffic: channel('traffic'),
+    session: channel('session')
+  };
 
   return { ...base, publicSessionId, channels };
 };

--- a/src/options.context.ts
+++ b/src/options.context.ts
@@ -37,10 +37,8 @@ const getPublicSessionHash = (sessionId: string): string =>
 /**
  * Initialize and return session data.
  *
- * @note Potential breaking change with the move to using `mode` in channel names.
- * However, the session ID shifts, so we're unclear why someone would be using
- * the whole channel name, plus there's a provided callback associated with
- * logging. We'll note the update in release notes.
+ * @note Potential breaking change: Channel names now include `mode`. Consumers
+ * who leverage the logging callback, from server core, remain unaffected.
  *
  * @returns {AppSession} Immutable session with a session ID and channel name.
  */
@@ -187,10 +185,8 @@ const getLoggerOptions = (session = getSessionOptions()): LoggingSession => {
 /**
  * Get stat channel options from the current context.
  *
- * @note Potential breaking change with the move to using `mode` in channel names.
- * However, the session ID shifts, so we're unclear why someone would be using
- * the whole channel name, plus there's a provided callback associated with
- * stats. We'll note the update in release notes.
+ * @note Potential breaking change: Channel names now include `mode`. Consumers
+ * who leverage the stat's callback, from server core, remain unaffected.
  *
  * @param {AppSession} [options] - Session options to use in context.
  * @returns {StatsSession} Stats options from context.

--- a/src/options.context.ts
+++ b/src/options.context.ts
@@ -37,6 +37,11 @@ const getPublicSessionHash = (sessionId: string): string =>
 /**
  * Initialize and return session data.
  *
+ * @note Potential breaking change with the move to using `mode` in channel names.
+ * However, the session ID shifts, so we're unclear why someone would be using
+ * the whole channel name, plus there's a provided callback associated with
+ * logging. We'll note the update in release notes.
+ *
  * @returns {AppSession} Immutable session with a session ID and channel name.
  */
 const initializeSession = (): AppSession => {
@@ -181,6 +186,11 @@ const getLoggerOptions = (session = getSessionOptions()): LoggingSession => {
 
 /**
  * Get stat channel options from the current context.
+ *
+ * @note Potential breaking change with the move to using `mode` in channel names.
+ * However, the session ID shifts, so we're unclear why someone would be using
+ * the whole channel name, plus there's a provided callback associated with
+ * stats. We'll note the update in release notes.
  *
  * @param {AppSession} [options] - Session options to use in context.
  * @returns {StatsSession} Stats options from context.

--- a/src/options.defaults.ts
+++ b/src/options.defaults.ts
@@ -445,9 +445,9 @@ const XHR_FETCH_OPTIONS: XhrFetchOptions = {
 };
 
 /**
- * Base logging channel name. Fixed to avoid user override.
+ * Base diagnostics channel name. Fixed to avoid user override and channel collisions.
  */
-const LOG_BASENAME = 'pf-mcp:log';
+const CHANNEL_BASENAME = 'pf-mcp';
 
 /**
  * Default PatternFly-specific options.
@@ -539,7 +539,7 @@ const DEFAULT_OPTIONS: DefaultOptions = {
 
 export {
   DEFAULT_OPTIONS,
-  LOG_BASENAME,
+  CHANNEL_BASENAME,
   MODE_LEVELS,
   PLUGIN_ISOLATION,
   type DefaultOptions,


### PR DESCRIPTION
<!-- 
Before you open a PR, make sure you have reviewed our contribution guidelines:
https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md

PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues and PRs for confirmation that the work isn't already in progress.
-->

## What is it?
<!-- Summary of changes/additions/commits -->
- refactor(options): pf-3874 log to channel basename

### Notes
- base work for breaking the channel names apart dependent on operation mode
- potential breaking change for anyone using the `stats` and `log` channel names directly. anyone using the intended callbacks without attempting to parse the  channel names, like splitting them, remains unaffected. we'll add a short callout next release

<!-- ## How to test-->
<!-- Are there directions to test/review? -->

<!--
### Prompt an agent to
1. `> [test prompt]`
-->

<!--
### Check the work
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. `npx -y @modelcontextprotocol/inspector node dist/cli.js`
1. next...
-->

<!--
### Unit test check
1. Update the NPM packages with `$ npm install`
1. `$ npm test`
-->

<!--
### E2E test check
1. Update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->

<!--
### Check the build
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related to #148   and pf-3874

#239 #223