### PR TITLE
test: pf-4387 stdio client logging flake

### DIFF
--- a/tests/e2e/utils/stdioTransportClient.ts
+++ b/tests/e2e/utils/stdioTransportClient.ts
@@ -124,6 +124,15 @@ export const startServer = async ({
   const stderrLogs: string[] = [];
   let logBuffer = '';
 
+  /*
+   * Log streaming, partials are unavoidable. `stderr` gives us bytes, not lines.
+   * The returned `\n` from the writer is the only "line done" signal. We could attempt
+   * to wait for the `\n` and only return full completions, but we've opted to return
+   * the partials as they arrive. Basically, if you attempt to `equal` a log instead of
+   * using `contains` or `includes`, the test may fail, and you'll be disappointed.
+   *
+   * Subject to change; for now partials are returned as-is.
+   */
   if (transport.stderr) {
     transport.stderr.on('data', (data: Buffer) => {
       logBuffer += data.toString();

--- a/tests/e2e/utils/stdioTransportClient.ts
+++ b/tests/e2e/utils/stdioTransportClient.ts
@@ -122,10 +122,17 @@ export const startServer = async ({
   // Access stderr stream if available. stderr is used to prevent logs from interfering with JSON-RPC parsing
   // Collect server stderr logs
   const stderrLogs: string[] = [];
+  let logBuffer = '';
 
   if (transport.stderr) {
     transport.stderr.on('data', (data: Buffer) => {
-      stderrLogs.push(data.toString());
+      logBuffer += data.toString();
+      const lines = logBuffer.split('\n');
+
+      logBuffer = lines.pop() || '';
+      for (const line of lines) {
+        stderrLogs.push(`${line}\n`);
+      }
     });
   }
 
@@ -234,9 +241,13 @@ export const startServer = async ({
 
     logs: () => [
       ...stderrLogs,
+      ...(logBuffer ? [logBuffer] : []),
       ...protocolLogs
     ],
-    stderrLogs: () => stderrLogs.slice(),
+    stderrLogs: () => [
+      ...stderrLogs,
+      ...(logBuffer ? [logBuffer] : [])
+    ],
     protocolLogs: () => protocolLogs.slice(),
     stop,
     close: stop // Alias for stop, align with the http transport client


### PR DESCRIPTION


<!-- 
Before you open a PR, make sure you have reviewed our contribution guidelines:
https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md

PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues and PRs for confirmation that the work isn't already in progress.
-->

## What is it?
<!-- Summary of changes/additions/commits -->
- test: pf-4387 stdio client logging flake
   * e2e, stdio client logging, long-standing flake. related fetch updates make it consistent
### Notes
- upcoming fetch work in #248 makes this issue appear consistently.
- remanent flake from early stdio client work for e2e, left it in place to help highlight over-zealous bot work

<!-- ## How to test-->
<!-- Are there directions to test/review? -->

<!--
### Prompt an agent to
1. `> [test prompt]`
-->

<!--
### Check the work
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. `npx -y @modelcontextprotocol/inspector node dist/cli.js`
1. next...
-->

<!--
### Unit test check
1. Update the NPM packages with `$ npm install`
1. `$ npm test`
-->

<!--
### E2E test check
1. Update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->

<!--
### Check the build
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
updates #240 PF-4387