### PR TITLE
fix(assertions): pf-4387 block non-urls

### DIFF
--- a/src/__tests__/__snapshots__/tool.patternFlyDocs.test.ts.snap
+++ b/src/__tests__/__snapshots__/tool.patternFlyDocs.test.ts.snap
@@ -12,8 +12,6 @@ exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, mul
 
 exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, single file, mock path 1`] = `"# Content for components/button.md"`;
 
-exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, with invalid urlList 1`] = `"# Content for invalid-path"`;
-
 exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, with name and actual path 1`] = `"# Content for documentation:chatbot/README.md"`;
 
 exports[`usePatternFlyDocsTool, callback should have a specific markdown format: Button 1`] = `

--- a/src/__tests__/server.assertions.test.ts
+++ b/src/__tests__/server.assertions.test.ts
@@ -293,6 +293,31 @@ describe('assertInputStringNumberEnumLike', () => {
 describe('assertInputUrlWhiteListed', () => {
   it.each([
     {
+      description: 'empty string',
+      input: '',
+      compare: ['https://patternfly.org']
+    },
+    {
+      description: 'undefined',
+      input: undefined,
+      compare: ['https://patternfly.org']
+    },
+    {
+      description: 'null',
+      input: null,
+      compare: ['https://patternfly.org']
+    },
+    {
+      description: 'number',
+      input: 1,
+      compare: ['https://patternfly.org']
+    },
+    {
+      description: 'string',
+      input: 'lorem ipsum',
+      compare: ['https://patternfly.org']
+    },
+    {
       description: 'URL and display name',
       input: 'https://github.com/patternfly',
       compare: ['https://patternfly.org'],
@@ -322,7 +347,7 @@ describe('assertInputUrlWhiteListed', () => {
     const errorMessage = 'Lorem ipsum error message for validation.';
 
     expect(() => assertInputUrlWhiteListed(
-      'https://github.com/patternfly',
+      false,
       ['http://patternfly.org'],
       { message: errorMessage, codeOrError: (message, cause) => new Error(`Custom: ${message}`, { cause }) }
     )).toThrow(`Custom: ${errorMessage}`);

--- a/src/__tests__/tool.patternFlyDocs.test.ts
+++ b/src/__tests__/tool.patternFlyDocs.test.ts
@@ -64,7 +64,7 @@ describe('usePatternFlyDocsTool, callback', () => {
         path: 'components/button.md',
         content: 'single documentation content'
       },
-      urlList: ['components/button.md']
+      urlList: ['https://www.patternfly.org/components/button.md']
     },
     {
       description: 'multiple files, mock paths',
@@ -72,15 +72,11 @@ describe('usePatternFlyDocsTool, callback', () => {
         path: 'components/button.md',
         content: 'combined documentation content'
       },
-      urlList: ['components/button.md', 'components/card.md', 'components/table.md']
-    },
-    {
-      description: 'with invalid urlList',
-      processedValue: {
-        path: 'invalid-path',
-        content: 'Failed to load'
-      },
-      urlList: ['invalid-url']
+      urlList: [
+        'https://www.patternfly.org/components/button.md',
+        'https://www.patternfly.org/components/card.md',
+        'https://www.patternfly.org/components/table.md'
+      ]
     },
     {
       description: 'with name and actual path',

--- a/src/server.assertions.ts
+++ b/src/server.assertions.ts
@@ -230,7 +230,6 @@ function assertInputUrlWhiteListed(
 
   updatedInput.forEach(url => {
     const isRemote = typeof url === 'string' && allowedProtocols.some(protocol => url.startsWith(protocol));
-    const isPfUri = isPatternFlyUri(url);
 
     if (isRemote) {
       // Dive into condition to avoid flipping else
@@ -239,7 +238,7 @@ function assertInputUrlWhiteListed(
       }
     } else if (isUrl(url, { isStrict: false })) {
       // Dive into condition to avoid flipping else
-      if (!isPfUri) {
+      if (!isPatternFlyUri(url)) {
         invalidUrls.push(url);
       }
     } else {

--- a/src/server.assertions.ts
+++ b/src/server.assertions.ts
@@ -233,10 +233,16 @@ function assertInputUrlWhiteListed(
     const isPfUri = isPatternFlyUri(url);
 
     if (isRemote) {
+      // Dive into condition to avoid flipping else
       if (!isWhitelistedUrl(url, whitelist, { allowedProtocols })) {
         invalidUrls.push(url);
       }
-    } else if (isUrl(url, { isStrict: false }) && !isPfUri) {
+    } else if (isUrl(url, { isStrict: false })) {
+      // Dive into condition to avoid flipping else
+      if (!isPfUri) {
+        invalidUrls.push(url);
+      }
+    } else {
       invalidUrls.push(url);
     }
   });


### PR DESCRIPTION
<!-- 
Before you open a PR, make sure you have reviewed our contribution guidelines:
https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md

PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues and PRs for confirmation that the work isn't already in progress.
-->

## What is it?
<!-- Summary of changes/additions/commits -->
- fix(assertions): pf-4387 block non-urls
### Notes
- fixes a low-level bug around whitelisted urls where trash or non-url values would simply pass through the assertion. now they don't

<!-- ## How to test-->
<!-- Are there directions to test/review? -->

<!--
### Prompt an agent to
1. `> [test prompt]`
-->

<!--
### Check the work
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. `npx -y @modelcontextprotocol/inspector node dist/cli.js`
1. next...
-->

<!--
### Unit test check
1. Update the NPM packages with `$ npm install`
1. `$ npm test`
-->

<!--
### E2E test check
1. Update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->

<!--
### Check the build
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
updates #240 PF-4387

related #252 