### PR TITLE
refactor: pf-4402 add tool, resource provenance

### DIFF
--- a/src/__tests__/__snapshots__/tool.patternFlyDocs.test.ts.snap
+++ b/src/__tests__/__snapshots__/tool.patternFlyDocs.test.ts.snap
@@ -8,22 +8,24 @@ exports[`usePatternFlyDocsTool should have a consistent return structure: struct
 }
 `;
 
-exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, multiple files, mock paths 1`] = `"# Content for components/button.md"`;
+exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, multiple files, mock paths 1`] = `"<!-- mcp:provenance id="components/button.md" -->"`;
 
-exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, single file, mock path 1`] = `"# Content for components/button.md"`;
+exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, single file, mock path 1`] = `"<!-- mcp:provenance id="components/button.md" -->"`;
 
-exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, with name and actual path 1`] = `"# Content for documentation:chatbot/README.md"`;
+exports[`usePatternFlyDocsTool, callback should attempt to parse parameters, with name and actual path 1`] = `"<!-- mcp:provenance id="documentation:chatbot/README.md" -->"`;
 
 exports[`usePatternFlyDocsTool, callback should have a specific markdown format: Button 1`] = `
 [
   {
-    "text": "# Documentation for Button (v6) [Documentation]
+    "text": "<!-- mcp:provenance id="components/loremButton.md" -->
+# Documentation for Button (v6) [Documentation]
 Source: components/loremButton.md
 
 lorem documentation content
 
 ---
 
+<!-- mcp:provenance id="components/ipsumButton.md" -->
 # Content for components/ipsumButton.md
 Source: components/ipsumButton.md
 

--- a/src/resource.patternFlyDocsTemplate.ts
+++ b/src/resource.patternFlyDocsTemplate.ts
@@ -118,7 +118,8 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
   try {
     const docPaths = byEntry
       .filter(({ path }) => path)
-      .map(({ path, uriId }) => ({ doc: path, uri: uriId }));
+      .map(({ path, uriId, id, groupId, displayName, displayCategory, version: entryVersion }) =>
+        ({ doc: path, uri: uriId, id, groupId, displayName, displayCategory, entryVersion }));
 
     if (docPaths.length > 0) {
       // `processDocsFunction` has de-dup docs baked in
@@ -172,11 +173,12 @@ const resourceCallback = async (passedUri: URL, variables: Record<string, string
   }
 
   return {
-    contents: docs.map(({ uri, path, resolvedPath, content }) => ({
+    contents: docs.map(({ uri, content, id, groupId, displayName, displayCategory, entryVersion }) => ({
       uri,
       mimeType: 'text/markdown',
       text: stringJoin.newline(
-        `# Documentation from ${resolvedPath || path}`,
+        `<!-- mcp:provenance id="${id}" groupId="${groupId}" -->`,
+        `# Documentation for ${displayName} - ${displayCategory} (${entryVersion})`,
         '',
         content
       )

--- a/src/tool.patternFlyDocs.ts
+++ b/src/tool.patternFlyDocs.ts
@@ -189,15 +189,20 @@ const usePatternFlyDocsTool = (options = getOptions()): McpTool => {
 
     for (const doc of docs) {
       const patternFlyEntry = doc.path ? byPath[doc.path] : undefined;
+      const entryId = patternFlyEntry?.id;
+      const entryGroupId = patternFlyEntry?.groupId;
       const entryName = patternFlyEntry?.name;
       const entryVersion = patternFlyEntry?.version;
       const entryVersionDisplay = (entryVersion && ` (${entryVersion})`) || '';
+
+      const provenance = entryId ? `<!-- mcp:provenance id="${entryId}" groupId="${entryGroupId}" -->` : `<!-- mcp:provenance id="${doc.path}" -->`;
 
       const docTitle = patternFlyEntry
         ? `# Documentation for ${patternFlyEntry?.displayName || entryName}${entryVersionDisplay} [${setCategoryDisplayLabel(patternFlyEntry)}]`
         : `# Content for ${doc.path}`;
 
       docResults.push(stringJoin.newline(
+        provenance,
         docTitle,
         `Source: ${doc.path}`,
         '',

--- a/tests/e2e/__snapshots__/httpTransport.test.ts.snap
+++ b/tests/e2e/__snapshots__/httpTransport.test.ts.snap
@@ -70,7 +70,8 @@ Use these parameters to filter the list of PatternFly component schemas.
 `;
 
 exports[`Builtin tools, HTTP transport should concatenate headers and separator with two remote files 1`] = `
-"# Content for https://www.patternfly.org/notARealPath/AboutModal.md
+"<!-- mcp:provenance id="https://www.patternfly.org/notARealPath/AboutModal.md" -->
+# Content for https://www.patternfly.org/notARealPath/AboutModal.md
 Source: https://www.patternfly.org/notARealPath/AboutModal.md
 
 # Test Document
@@ -79,6 +80,7 @@ This is a test document for mocking remote HTTP requests.
 
 ---
 
+<!-- mcp:provenance id="https://www.patternfly.org/notARealPath/ChartLegend.md" -->
 # Content for https://www.patternfly.org/notARealPath/ChartLegend.md
 Source: https://www.patternfly.org/notARealPath/ChartLegend.md
 

--- a/tests/e2e/__snapshots__/stdioTransport.test.ts.snap
+++ b/tests/e2e/__snapshots__/stdioTransport.test.ts.snap
@@ -70,7 +70,8 @@ Use these parameters to filter the list of PatternFly component schemas.
 `;
 
 exports[`Builtin tools, STDIO should concatenate headers and separator with two remote files 1`] = `
-"# Content for http://127.0.0.1:5010/notARealPath/AboutModal.md
+"<!-- mcp:provenance id="http://127.0.0.1:5010/notARealPath/AboutModal.md" -->
+# Content for http://127.0.0.1:5010/notARealPath/AboutModal.md
 Source: http://127.0.0.1:5010/notARealPath/AboutModal.md
 
 # Test Document
@@ -79,6 +80,7 @@ This is a test document for mocking remote HTTP requests.
 
 ---
 
+<!-- mcp:provenance id="http://127.0.0.1:5010/notARealPath/README.md" -->
 # Content for http://127.0.0.1:5010/notARealPath/README.md
 Source: http://127.0.0.1:5010/notARealPath/README.md
 


### PR DESCRIPTION
<!-- 
Before you open a PR, make sure you have reviewed our contribution guidelines:
https://github.com/patternfly/patternfly-mcp/blob/main/CONTRIBUTING.md

PR tips
- Updates to MCP architecture, resources, prompts, and tools require an issue being opened first.
- Review existing issues and PRs for confirmation that the work isn't already in progress.
-->

## What is it?
<!-- Summary of changes/additions/commits -->
- refactor: pf-4402 add tool, resource provenance

### Notes
- refactor provenance paths so agents "mostly" avoid broadcasting them to end users
- this popped up during audit checks for the api work, agents would broadcast the API path to an end user not realizing it was a stream

<!-- ## How to test-->
<!-- Are there directions to test/review? -->

<!--
### Prompt an agent to
1. `> [test prompt]`
-->

<!--
### Check the work
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. `npx -y @modelcontextprotocol/inspector node dist/cli.js`
1. next...
-->

<!--
### Unit test check
1. Update the NPM packages with `$ npm install`
1. `$ npm test`
-->

<!--
### E2E test check
1. Update the NPM packages with `$ npm install`
1. `$ npm run test:integration`
-->

<!--
### Check the build
1. Update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
updates pf-4402 #242 